### PR TITLE
feat: implement web missing auth session

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,14 +121,14 @@ La aplicación está configurada para trabajar con SISCOM-ADMIN-API (FastAPI). L
 
 ```json
 {
- "access_token": "eyJhbGciOiJSUzI1...",
- "id_token": "eyJhbGciOiJSUzI1...",
- "refresh_token": "eyJjdHkiOiJKV1Q...",
- "expires_in": 3600,
- "token_type": "Bearer",
- "user_id": "123e4567-e89b-12d3-a456-426614174000",
- "email": "usuario@ejemplo.com",
- "email_verified": true
+	"access_token": "eyJhbGciOiJSUzI1...",
+	"id_token": "eyJhbGciOiJSUzI1...",
+	"refresh_token": "eyJjdHkiOiJKV1Q...",
+	"expires_in": 3600,
+	"token_type": "Bearer",
+	"user_id": "123e4567-e89b-12d3-a456-426614174000",
+	"email": "usuario@ejemplo.com",
+	"email_verified": true
 }
 ```
 
@@ -171,9 +171,9 @@ Edita `src/routes/dashboard/+page.svelte`:
 
 ```javascript
 const mapOptions = {
- center: { lat: TU_LATITUD, lng: TU_LONGITUD },
- zoom: 13
- // ...
+	center: { lat: TU_LATITUD, lng: TU_LONGITUD },
+	zoom: 13
+	// ...
 };
 ```
 

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { fade, fly } from 'svelte/transition';
 	import { goto } from '$app/navigation';
-	import { user, authToken } from '$lib/stores/auth.js';
+	import { logoutSession } from '$lib/services/sessionService.js';
 	import UserPanel from './UserPanel.svelte';
 	import VehiclePanel from './VehiclePanel.svelte';
 	import AdminPanel from './AdminPanel.svelte';
@@ -23,9 +23,8 @@
 		activeMenu = null;
 	}
 
-	function handleLogout() {
-		user.logout();
-		authToken.clearToken();
+	async function handleLogout() {
+		await logoutSession();
 		goto('/login');
 	}
 </script>

--- a/src/lib/components/TabAjustes.svelte
+++ b/src/lib/components/TabAjustes.svelte
@@ -1,7 +1,8 @@
 <script>
 	import Icon from '@iconify/svelte';
 	import { goto } from '$app/navigation';
-	import { user, authToken } from '$lib/stores/auth.js';
+	import { user } from '$lib/stores/auth.js';
+	import { logoutSession } from '$lib/services/sessionService.js';
 	import { vehicles, vehicleActions, loadingVehicles } from '$lib/stores/vehicleStore.js';
 	import { getStatusText, getStatusPillClass } from '$lib/utils/vehicleUtils.js';
 	import { theme, themeActions } from '$lib/stores/themeStore.js';
@@ -12,9 +13,8 @@
 		return name ? name.charAt(0).toUpperCase() : '?';
 	}
 
-	function handleLogout() {
-		user.logout();
-		authToken.clearToken();
+	async function handleLogout() {
+		await logoutSession();
 		goto('/login');
 	}
 

--- a/src/lib/components/UserPanel.svelte
+++ b/src/lib/components/UserPanel.svelte
@@ -2,7 +2,7 @@
 	import { goto } from '$app/navigation';
 	import Icon from '@iconify/svelte';
 	import CenterSheet from '$lib/components/CenterSheet.svelte';
-	import { user, authToken } from '$lib/stores/auth.js';
+	import { logoutSession } from '$lib/services/sessionService.js';
 	import { theme, themeActions } from '$lib/stores/themeStore.js';
 
 	export let showUserPanel = false;
@@ -12,9 +12,8 @@
 
 	$: isLightTheme = $theme === 'light';
 
-	function handleLogout() {
-		user.logout();
-		authToken.clearToken();
+	async function handleLogout() {
+		await logoutSession();
 		goto('/login');
 	}
 </script>

--- a/src/lib/services/sessionService.js
+++ b/src/lib/services/sessionService.js
@@ -1,0 +1,67 @@
+import { user, authToken } from '$lib/stores/auth.js';
+import { apiService } from '$lib/services/api.js';
+
+/** @param {Record<string, unknown> | null | undefined} apiUser */
+export function normalizeUser(apiUser) {
+	if (!apiUser) return null;
+	return {
+		...apiUser,
+		name: apiUser.name || apiUser.full_name || '',
+		is_master: apiUser.is_master ?? apiUser.role === 'master'
+	};
+}
+
+/** @param {{ access_token?: string, refresh_token?: string, id_token?: string, expires_in?: number, user?: Record<string, unknown> }} response */
+export function persistLoginResponse(response) {
+	authToken.setSession({
+		access_token: response.access_token,
+		refresh_token: response.refresh_token,
+		id_token: response.id_token,
+		expires_in: response.expires_in
+	});
+	user.login(normalizeUser(response.user));
+}
+
+export function clearLocalSession() {
+	user.logout();
+	authToken.clearToken();
+}
+
+export async function logoutSession() {
+	if (authToken.getToken()) {
+		try {
+			await apiService.logout();
+		} catch (err) {
+			console.warn('Logout API failed; clearing local session anyway:', err);
+		}
+	}
+	clearLocalSession();
+}
+
+export async function validateSessionWithApi() {
+	user.init();
+	authToken.init();
+
+	if (!authToken.getToken()) {
+		clearLocalSession();
+		return false;
+	}
+
+	try {
+		const apiUser = await apiService.getCurrentUser();
+		user.login(normalizeUser(apiUser));
+		return true;
+	} catch (err) {
+		console.warn('Session validation failed:', err);
+		clearLocalSession();
+		return false;
+	}
+}
+
+export function getRecoverPasswordUrl() {
+	const base = String(import.meta.env.VITE_COMPANY_URL || '')
+		.trim()
+		.replace(/\/$/, '');
+	if (!base) return null;
+	return `${base}/auth?mode=recover`;
+}

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -7,6 +7,7 @@
 	import { scale, fly } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
 	import { user } from '$lib/stores/auth.js';
+	import { validateSessionWithApi, logoutSession } from '$lib/services/sessionService.js';
 	import { activeTab } from '$lib/stores/navigationStore.js';
 	import {
 		h3Actions,
@@ -180,23 +181,35 @@
 	}
 
 	onMount(() => {
-		user.init();
-		const unsubscribe = user.subscribe((data) => {
-			userData = data;
-			if (!data) {
+		let unsubscribe = () => {};
+
+		(async () => {
+			const sessionOk = await validateSessionWithApi();
+			if (!sessionOk) {
 				goto('/login');
 				return;
 			}
-			alertActions.syncZonesFromApi().catch((err) => {
-				console.error('No se pudieron sincronizar las geocercas:', err);
+
+			isLoading = false;
+
+			unsubscribe = user.subscribe((data) => {
+				userData = data;
+				if (!data) {
+					goto('/login');
+					return;
+				}
+				alertActions.syncZonesFromApi().catch((err) => {
+					console.error('No se pudieron sincronizar las geocercas:', err);
+				});
+				alertActions.syncAlertRulesFromApi().catch((err) => {
+					console.error('No se pudieron sincronizar las reglas de alerta:', err);
+				});
+				alertActions.syncAlarmEventsFromApi().catch((err) => {
+					console.error('No se pudo sincronizar el historial de alertas:', err);
+				});
 			});
-			alertActions.syncAlertRulesFromApi().catch((err) => {
-				console.error('No se pudieron sincronizar las reglas de alerta:', err);
-			});
-			alertActions.syncAlarmEventsFromApi().catch((err) => {
-				console.error('No se pudo sincronizar el historial de alertas:', err);
-			});
-		});
+		})();
+
 		if (browser) {
 			document.addEventListener('fullscreenchange', syncFullscreen);
 			document.addEventListener('webkitfullscreenchange', syncFullscreen);
@@ -353,8 +366,8 @@
 						<button
 							type="button"
 							class="flex w-full cursor-pointer items-center gap-2 rounded-lg border-0 bg-red-500/10 px-3 py-2.5 text-sm font-medium text-red-400 transition-colors hover:bg-red-500/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400/50 justify-center"
-							on:click={() => {
-								user.logout?.();
+							on:click={async () => {
+								await logoutSession();
 								goto('/login');
 							}}
 						>

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -2,7 +2,8 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
 	import { user, authToken } from '$lib/stores/auth.js';
-	import { apiService } from '$lib/services/api.js';
+	import { apiService, ApiError } from '$lib/services/api.js';
+	import { getRecoverPasswordUrl, persistLoginResponse } from '$lib/services/sessionService.js';
 	import { onMount } from 'svelte';
 	import Icon from '@iconify/svelte';
 	import logoUrl from '$lib/assets/logo.png';
@@ -13,17 +14,31 @@
 	let error = '';
 	let showPassword = false;
 
-	// Redirigir si ya está autenticado
+	const recoverPasswordUrl = getRecoverPasswordUrl();
+
 	onMount(() => {
 		user.init();
 		authToken.init();
 		const unsubscribe = user.subscribe((userData) => {
-			if (userData) {
+			if (userData && authToken.getToken()) {
 				goto('/dashboard');
 			}
 		});
 		return unsubscribe;
 	});
+
+	function loginErrorMessage(err) {
+		if (err instanceof ApiError) {
+			if (err.status === 403) {
+				return err.displayMessage || 'Debes verificar tu correo antes de iniciar sesión.';
+			}
+			if (err.status === 401) {
+				return 'Credenciales inválidas. Por favor, intenta de nuevo.';
+			}
+			return err.displayMessage || 'No se pudo iniciar sesión.';
+		}
+		return 'Credenciales inválidas. Por favor, intenta de nuevo.';
+	}
 
 	async function handleLogin() {
 		if (loading) return;
@@ -38,24 +53,10 @@
 
 		try {
 			const response = await apiService.login({ email, password });
-			const apiUser = response?.user || {};
-			const normalizedUser = {
-				...apiUser,
-				name: apiUser.name || apiUser.full_name || ''
-			};
-
-			authToken.setSession({
-				access_token: response.access_token,
-				refresh_token: response.refresh_token,
-				id_token: response.id_token,
-				expires_in: response.expires_in
-			});
-			user.login(normalizedUser);
-
-			// Redirigir al dashboard
+			persistLoginResponse(response);
 			goto('/dashboard');
 		} catch (err) {
-			error = 'Credenciales inválidas. Por favor, intenta de nuevo.';
+			error = loginErrorMessage(err);
 		} finally {
 			loading = false;
 		}
@@ -185,6 +186,17 @@
 					</button>
 				</div>
 			</div>
+
+			{#if recoverPasswordUrl}
+				<p class="m-0 text-center text-[0.8125rem]">
+					<a
+						href={recoverPasswordUrl}
+						class="font-medium text-blue-600 no-underline hover:underline dark:text-blue-400"
+					>
+						¿Olvidaste tu contraseña?
+					</a>
+				</p>
+			{/if}
 
 			<button
 				type="submit"

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ApiError } from '../src/lib/services/apiErrors.js';
+import { normalizeUser, getRecoverPasswordUrl } from '../src/lib/services/sessionService.js';
+
+describe('apiErrors', () => {
+	it('ApiError expone detail del backend', () => {
+		const err = new ApiError('HTTP error', { status: 403, detail: 'Email no verificado' });
+		expect(err.displayMessage).toBe('Email no verificado');
+	});
+});
+
+describe('sessionService', () => {
+	it('normalizeUser unifica nombre y rol master', () => {
+		expect(normalizeUser({ full_name: 'Ana', role: 'master' })).toMatchObject({
+			name: 'Ana',
+			is_master: true
+		});
+	});
+
+	it('getRecoverPasswordUrl usa VITE_COMPANY_URL', () => {
+		vi.stubEnv('VITE_COMPANY_URL', 'https://geminis.dev');
+		expect(getRecoverPasswordUrl()).toBe('https://geminis.dev/auth?mode=recover');
+		vi.unstubAllEnvs();
+	});
+
+	it('getRecoverPasswordUrl devuelve null sin URL configurada', () => {
+		vi.stubEnv('VITE_COMPANY_URL', '');
+		expect(getRecoverPasswordUrl()).toBeNull();
+		vi.unstubAllEnvs();
+	});
+});


### PR DESCRIPTION
## Summary
Completa el flujo de sesión de la web Nexus :
- Valida la sesión al entrar al dashboard con `GET /users/me`.
- Centraliza login/logout en `sessionService.js` (`persistLoginResponse`, `validateSessionWithApi`, `logoutSession`).
- Logout revoca sesión en backend (`POST /auth/logout`) antes de limpiar tokens locales.
- Login: errores 401/403 legibles vía `ApiError`; enlace a recuperación de contraseña en Geminis Labs (`VITE_COMPANY_URL/auth?mode=recover`).
Refresh proactivo e interceptor 401

## Cambios principales
- `src/lib/services/sessionService.js` (nuevo)
- `src/routes/login/+page.svelte` — sesión completa + forgot password
- `src/routes/dashboard/+page.svelte` — guard con `/users/me`
- Logout unificado en UserPanel, TabAjustes, Sidebar y menú dashboard
- `tests/auth.test.js` — helpers de sesión