### PR TITLE
feat(web): add unit profiles and contextual tracking panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .npmrc
+.idea
 
 # Output
 .output

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"@sveltejs/vite-plugin-svelte": "^6.0.0",
 				"@tailwindcss/postcss": "^4.1.13",
 				"@tailwindcss/typography": "^0.5.16",
-				"@types/node": "^22.12.0",
+				"@types/node": "^25.9.1",
 				"autoprefixer": "^10.4.21",
 				"postcss": "^8.5.6",
 				"prettier": "^3.4.2",
@@ -1054,9 +1054,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@sveltejs/acorn-typescript": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
-			"integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
+			"integrity": "sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==",
 			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^8.9.0"
@@ -1089,9 +1089,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.60.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.60.1.tgz",
-			"integrity": "sha512-mQjlkNo+rJvpln7V2IGY2j99BqhcFbS4UN0AQNKNYfhBAFZTuCDAdW3a1sgf330mvtNvsBXn3HpAhcmvdJTcIQ==",
+			"version": "2.57.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.57.1.tgz",
+			"integrity": "sha512-VRdSbB96cI1EnRh09CqmnQqP/YJvET5buj8S6k7CxaJqBJD4bw4fRKDjcarAj/eX9k2eHifQfDH8NtOh+ZxxPw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1100,7 +1100,7 @@
 				"@types/cookie": "^0.6.0",
 				"acorn": "^8.14.1",
 				"cookie": "^0.6.0",
-				"devalue": "^5.8.1",
+				"devalue": "^5.6.4",
 				"esm-env": "^1.2.2",
 				"kleur": "^4.1.5",
 				"magic-string": "^0.30.5",
@@ -3627,13 +3627,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "22.19.19",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-			"integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+			"version": "25.9.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+			"integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~6.21.0"
+				"undici-types": ">=7.24.0 <7.24.7"
 			}
 		},
 		"node_modules/@types/resolve": {
@@ -4106,9 +4106,9 @@
 			}
 		},
 		"node_modules/devalue": {
-			"version": "5.8.1",
-			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
-			"integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
+			"integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
 			"license": "MIT"
 		},
 		"node_modules/earcut": {
@@ -4214,9 +4214,9 @@
 			"license": "MIT"
 		},
 		"node_modules/esrap": {
-			"version": "2.2.9",
-			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.9.tgz",
-			"integrity": "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.5.tgz",
+			"integrity": "sha512-/yLB1538mag+dn0wsePTe8C0rDIjUOaJpMs2McodSzmM2msWcZsBSdRtg6HOBt0A/r82BN+Md3pgwSc/uWt2Ig==",
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
@@ -4795,9 +4795,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.12",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
 			"dev": true,
 			"funding": [
 				{
@@ -4906,9 +4906,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.15",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+			"version": "8.5.6",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
 			"dev": true,
 			"funding": [
 				{
@@ -4926,7 +4926,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -5171,23 +5171,23 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.55.9",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.9.tgz",
-			"integrity": "sha512-fTjjT8cHLDwigcu2j3pv7Jq04LklXevPB8uBgyHNiTXv+RMNvVnrjS4UEYrLMkhuq1vpCodHjiW+z/95SDs/fg==",
+			"version": "5.55.4",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.4.tgz",
+			"integrity": "sha512-q8DFohk6vUswSng95IZb9nzWJnbINZsK7OiM1snAa3qCjJBL0ZQpvMyAaVXjUukdM75J/m8UE8xwqat8Ors/zQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
-				"@sveltejs/acorn-typescript": "^1.0.10",
+				"@sveltejs/acorn-typescript": "^1.0.5",
 				"@types/estree": "^1.0.5",
 				"@types/trusted-types": "^2.0.7",
 				"acorn": "^8.12.1",
 				"aria-query": "5.3.1",
 				"axobject-query": "^4.1.0",
 				"clsx": "^2.1.1",
-				"devalue": "^5.8.1",
+				"devalue": "^5.6.4",
 				"esm-env": "^1.2.1",
-				"esrap": "^2.2.9",
+				"esrap": "^2.2.4",
 				"is-reference": "^3.0.3",
 				"locate-character": "^3.0.0",
 				"magic-string": "^0.30.11",
@@ -5354,9 +5354,9 @@
 			"license": "0BSD"
 		},
 		"node_modules/undici-types": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"version": "7.24.6",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"@sveltejs/vite-plugin-svelte": "^6.0.0",
 		"@tailwindcss/postcss": "^4.1.13",
 		"@tailwindcss/typography": "^0.5.16",
-		"@types/node": "^22.12.0",
+		"@types/node": "^25.9.1",
 		"autoprefixer": "^10.4.21",
 		"postcss": "^8.5.6",
 		"prettier": "^3.4.2",

--- a/src/lib/components/MapContainer.svelte
+++ b/src/lib/components/MapContainer.svelte
@@ -95,6 +95,9 @@
 			map = await mapService.initialize(mapElement);
 			isLoading = false;
 			syncMapNavigationControls();
+			mapService.setOnVehicleMarkerClick((vehicle) => {
+				vehicleActions.setActiveUnit?.(vehicle?.id);
+			});
 
 			const mql = window.matchMedia(MOBILE_MQ);
 			const onViewportNav = () => syncMapNavigationControls();

--- a/src/lib/components/TrackingContextPanel.svelte
+++ b/src/lib/components/TrackingContextPanel.svelte
@@ -1,0 +1,256 @@
+<script>
+	import Icon from '@iconify/svelte';
+
+	export let unit = null;
+	export let units = [];
+	export let panelView = 'unit-info';
+	export let onPanelViewChange = () => {};
+	export let onSelectUnit = () => {};
+	export let onCenterUnit = () => {};
+
+	let showUnitPicker = false;
+	let searchQuery = '';
+
+	const panelActions = [
+		{ id: 'trips', label: 'Trayectos', icon: 'mdi:source-branch' },
+		{ id: 'events', label: 'Eventos', icon: 'mdi:bell-outline' },
+		{ id: 'details', label: 'Detalles', icon: 'mdi:information-outline' },
+		{ id: 'share', label: 'Compartir', icon: 'mdi:export-variant' }
+	];
+
+	$: filteredUnits = units.filter((u) => {
+		if (!searchQuery.trim()) return true;
+		const q = searchQuery.toLowerCase();
+		return (
+			u.name?.toLowerCase().includes(q) ||
+			u.brand?.toLowerCase().includes(q) ||
+			u.model?.toLowerCase().includes(q)
+		);
+	});
+
+	// Lógica de estado igual que Android/iOS (basada en engineStatus + speed + lastUpdate)
+	$: engineOn = unit?.engineStatus?.toUpperCase() === 'ON' || unit?.isOnline === true;
+	$: hasSignal = unit?.lastUpdate != null || unit?.gpsDatetime != null;
+	$: speed = Number(unit?.speed);
+	$: isMoving = !Number.isNaN(speed) && speed > 3;
+
+	$: statusLabel = (() => {
+		if (isMoving) return `${Math.round(speed)} km/h`;
+		if (engineOn) return 'Online';
+		if (!hasSignal) return 'Sin señal';
+		return 'Apagado';
+	})();
+
+	$: dateLabel = (() => {
+		const dateStr = unit?.gpsDatetime || unit?.lastUpdate;
+		if (!dateStr) return '';
+		const d = new Date(dateStr);
+		if (Number.isNaN(d.getTime())) return '';
+		const pad = (n) => String(n).padStart(2, '0');
+		return `${pad(d.getDate())}/${pad(d.getMonth() + 1)}/${String(d.getFullYear()).slice(-2)} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+	})();
+
+	// Voltajes igual que Android/iOS (mainBatteryVoltage, backupBatteryVoltage)
+	$: mainBattery = (() => {
+		const v = Number(unit?.mainBatteryVoltage ?? unit?.main_battery_voltage);
+		return !Number.isNaN(v) && v > 0 ? `${v.toFixed(1)}V` : '--';
+	})();
+
+	$: backupBattery = (() => {
+		const v = Number(unit?.backupBatteryVoltage ?? unit?.backup_battery_voltage);
+		return !Number.isNaN(v) && v > 0 ? `${v.toFixed(1)}V` : '--';
+	})();
+
+	// Satélites igual que Android/iOS
+	$: satelliteCount = (() => {
+		const s = Number(unit?.satellites);
+		return !Number.isNaN(s) && s >= 0 ? `x${s}` : 'x0';
+	})();
+
+	$: isOnline = engineOn || isMoving;
+
+	// Obtener estado de unidad (igual que Android/iOS)
+	function getUnitStatus(u) {
+		const spd = Number(u?.speed);
+		const moving = !Number.isNaN(spd) && spd > 3;
+		const engineOn = u?.engineStatus?.toUpperCase() === 'ON' || u?.isOnline === true;
+		const hasSignalUnit = u?.lastUpdate != null || u?.gpsDatetime != null;
+
+		if (moving)
+			return { label: `${Math.round(spd)} km/h`, color: 'text-emerald-400', dot: 'bg-emerald-400' };
+		if (engineOn) return { label: 'Online', color: 'text-emerald-400', dot: 'bg-emerald-400' };
+		if (!hasSignalUnit) return { label: 'Sin señal', color: 'text-red-500', dot: 'bg-red-500' };
+		return { label: 'Detenido', color: 'text-amber-500', dot: 'bg-amber-500' };
+	}
+
+	function formatUnitDate(u) {
+		if (!u?.lastUpdate) return '';
+		const d = new Date(u.lastUpdate);
+		if (Number.isNaN(d.getTime())) return '';
+		const pad = (n) => String(n).padStart(2, '0');
+		return `${pad(d.getDate())}/${pad(d.getMonth() + 1)}/${String(d.getFullYear()).slice(-2)} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+	}
+
+	function handleSelectUnit(u) {
+		onSelectUnit(u);
+		showUnitPicker = false;
+		searchQuery = '';
+	}
+</script>
+
+{#if unit}
+	<div
+		class="pointer-events-auto w-full rounded-t-2xl bg-[#0c1829] shadow-[0_-4px_20px_rgba(0,0,0,0.5)]"
+	>
+		<!-- Grabber -->
+		<div class="flex justify-center py-2">
+			<div class="h-1 w-9 rounded-full bg-white/30"></div>
+		</div>
+
+		<!-- Unit info -->
+		<div class="px-4 pb-3">
+			<div class="flex items-start gap-3">
+				<div class="min-w-0 flex-1">
+					<h2 class="m-0 truncate text-xl font-bold text-white">{unit.name}</h2>
+					<p class="m-0 text-sm text-white/60">
+						{[unit.brand, unit.model].filter(Boolean).join(' ') || 'Sin modelo'}
+					</p>
+					<p class="m-0 mt-1 flex items-center gap-1.5 text-sm">
+						<span
+							class="h-2 w-2 rounded-full {isOnline
+								? 'bg-emerald-400'
+								: hasSignal
+									? 'bg-amber-500'
+									: 'bg-red-500'}"
+						></span>
+						<span
+							class={isOnline ? 'text-emerald-400' : hasSignal ? 'text-amber-500' : 'text-red-500'}
+							>{statusLabel}</span
+						>
+						{#if dateLabel}
+							<span class="text-white/40">- {dateLabel}</span>
+						{/if}
+					</p>
+					<div class="mt-1 flex items-center gap-1 text-xs text-white/50">
+						<Icon icon="mdi:car-battery" class="h-3.5 w-3.5" />
+						<span>{mainBattery}</span>
+						<Icon icon="mdi:battery-outline" class="ml-1 h-3.5 w-3.5" />
+						<span>{backupBattery}</span>
+						<span class="mx-0.5">·</span>
+						<Icon icon="mdi:signal-cellular-3" class="h-3.5 w-3.5" />
+						<span>{satelliteCount}</span>
+					</div>
+				</div>
+				<button
+					type="button"
+					class="flex h-11 w-11 items-center justify-center rounded-full bg-sky-500 shadow-lg"
+					on:click={onCenterUnit}
+					aria-label="Centrar en mapa"
+				>
+					<Icon icon="mdi:navigation-variant" class="h-5 w-5 text-white" />
+				</button>
+			</div>
+		</div>
+
+		<!-- Unit picker toggle -->
+		{#if units.length > 1}
+			<button
+				type="button"
+				class="flex w-full items-center justify-between gap-2 border-t border-white/10 bg-white/5 px-4 py-2.5"
+				on:click={() => (showUnitPicker = !showUnitPicker)}
+				aria-expanded={showUnitPicker}
+			>
+				<div class="flex items-center gap-2">
+					<span
+						class="h-2.5 w-2.5 rounded-full {isOnline
+							? 'bg-emerald-400'
+							: hasSignal
+								? 'bg-amber-500'
+								: 'bg-red-500'}"
+					></span>
+					<span class="text-sm font-medium text-white">{unit.name}</span>
+					<span
+						class="rounded-full bg-white/10 px-1.5 py-0.5 text-[10px] font-semibold text-white/70"
+						>{units.length}</span
+					>
+				</div>
+				<Icon
+					icon={showUnitPicker ? 'mdi:chevron-up' : 'mdi:chevron-down'}
+					class="h-5 w-5 text-white/50"
+				/>
+			</button>
+		{/if}
+
+		<!-- Unit picker dropdown -->
+		{#if showUnitPicker}
+			<div class="border-t border-white/10 bg-[#0a1525]">
+				<!-- Search -->
+				<div class="p-3">
+					<div class="flex items-center gap-2 rounded-lg bg-white/10 px-3 py-2">
+						<Icon icon="mdi:magnify" class="h-5 w-5 text-white/40" />
+						<input
+							type="text"
+							placeholder="Buscar unidad..."
+							class="w-full bg-transparent text-sm text-white placeholder-white/40 outline-none"
+							bind:value={searchQuery}
+						/>
+					</div>
+				</div>
+				<!-- List -->
+				<ul class="max-h-48 overflow-y-auto px-3 pb-3">
+					{#each filteredUnits as u (u.id)}
+						{@const status = getUnitStatus(u)}
+						<li>
+							<button
+								type="button"
+								class="flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors hover:bg-white/5 {u.id ===
+								unit.id
+									? 'bg-white/10'
+									: ''}"
+								on:click={() => handleSelectUnit(u)}
+							>
+								<div class="flex h-10 w-10 items-center justify-center rounded-lg bg-slate-700/50">
+									<Icon icon="mdi:car-side" class="h-6 w-6 text-white/60" />
+								</div>
+								<div class="min-w-0 flex-1">
+									<p class="m-0 truncate text-sm font-semibold text-white">{u.name}</p>
+									<p class="m-0 text-xs text-white/50">
+										{[u.brand, u.model].filter(Boolean).join(' ') || 'Sin modelo'}
+									</p>
+									<p class="m-0 mt-0.5 flex items-center gap-1 text-xs">
+										<span class="h-1.5 w-1.5 rounded-full {status.dot}"></span>
+										<span class={status.color}>{status.label}</span>
+										{#if formatUnitDate(u)}
+											<span class="text-white/30">· {formatUnitDate(u)}</span>
+										{/if}
+									</p>
+								</div>
+								{#if u.id === unit.id}
+									<Icon icon="mdi:check-circle" class="h-5 w-5 text-sky-400" />
+								{:else}
+									<Icon icon="mdi:chevron-right" class="h-5 w-5 text-white/30" />
+								{/if}
+							</button>
+						</li>
+					{/each}
+				</ul>
+			</div>
+		{/if}
+
+		<!-- Actions -->
+		<div class="grid grid-cols-4 border-t border-white/10">
+			{#each panelActions as action, i}
+				<button
+					type="button"
+					class="flex flex-col items-center justify-center gap-1 py-3 {i > 0
+						? 'border-l border-white/10'
+						: ''} {panelView === action.id ? 'text-white' : 'text-white/50'}"
+					on:click={() => onPanelViewChange(action.id)}
+				>
+					<Icon icon={action.icon} class="h-5 w-5" />
+					<span class="text-[10px]">{action.label}</span>
+				</button>
+			{/each}
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/VehicleListPanel.svelte
+++ b/src/lib/components/VehicleListPanel.svelte
@@ -1,0 +1,156 @@
+<!-- src/lib/components/VehicleListPanel.svelte -->
+<script>
+	import Icon from '@iconify/svelte';
+	import { onMount } from 'svelte';
+	import {
+		vehicles,
+		loadingVehicles,
+		loadingPositions,
+		activeVehicles,
+		vehicleActions
+	} from '$lib/stores/vehicleStore.js';
+	import { mapService } from '$lib/services/mapService.js';
+
+	let collapsed = false;
+
+	onMount(async () => {
+		if ($vehicles.length === 0) {
+			await vehicleActions.loadVehicles();
+		}
+	});
+
+	function selectVehicle(v) {
+		vehicleActions.setActiveUnit(v.id);
+		mapService.centerOnVehicle(v);
+	}
+
+	function vehicleHasCoords(v) {
+		const lat = v?.latitude ?? v?.lat;
+		const lng = v?.longitude ?? v?.lng;
+		return lat != null && lng != null && !Number.isNaN(Number(lat)) && !Number.isNaN(Number(lng));
+	}
+
+	function getStatusDot(v) {
+		const spd = Number(v?.speed);
+		const moving = !Number.isNaN(spd) && spd > 3;
+		const engineOn = v?.engineStatus?.toUpperCase() === 'ON' || v?.isOnline === true;
+		const hasSignal = v?.lastUpdate != null || v?.gpsDatetime != null;
+		if (moving || engineOn) return 'bg-emerald-400';
+		if (!hasSignal) return 'bg-red-400';
+		return 'bg-amber-400';
+	}
+
+	function getStatusLabel(v) {
+		const spd = Number(v?.speed);
+		const moving = !Number.isNaN(spd) && spd > 3;
+		const engineOn = v?.engineStatus?.toUpperCase() === 'ON' || v?.isOnline === true;
+		const hasSignal = v?.lastUpdate != null || v?.gpsDatetime != null;
+		if (moving) return `${Math.round(spd)} km/h`;
+		if (engineOn) return 'Online';
+		if (!hasSignal) return 'Sin señal';
+		return 'Detenido';
+	}
+
+	function getStatusColor(v) {
+		const spd = Number(v?.speed);
+		const moving = !Number.isNaN(spd) && spd > 3;
+		const engineOn = v?.engineStatus?.toUpperCase() === 'ON' || v?.isOnline === true;
+		const hasSignal = v?.lastUpdate != null || v?.gpsDatetime != null;
+		if (moving || engineOn) return 'text-emerald-400';
+		if (!hasSignal) return 'text-red-400';
+		return 'text-amber-400';
+	}
+
+	$: activeCount = $activeVehicles?.length ?? 0;
+</script>
+
+<div
+	class="pointer-events-auto w-[300px] overflow-hidden rounded-2xl bg-[#0c1829] shadow-[0_-4px_20px_rgba(0,0,0,0.5)]"
+>
+	<!-- Header -->
+	<div class="flex items-center gap-2.5 border-b border-white/[0.08] px-4 py-3">
+		<span class="h-2 w-2 shrink-0 animate-pulse rounded-full bg-emerald-400" aria-hidden="true"
+		></span>
+		<p class="m-0 flex-1 text-xs font-semibold uppercase tracking-widest text-white/55">
+			Unidades
+			<span class="ml-1 font-bold text-emerald-400">{activeCount}</span><span class="text-white/30"
+				>/{$vehicles.length}</span
+			>
+		</p>
+		<button
+			type="button"
+			class="flex h-7 w-7 items-center justify-center rounded-lg text-white/35 transition-colors hover:bg-white/[0.06] hover:text-white/65"
+			on:click={() => (collapsed = !collapsed)}
+			aria-label={collapsed ? 'Expandir lista de unidades' : 'Colapsar lista de unidades'}
+			aria-expanded={!collapsed}
+		>
+			<Icon icon={collapsed ? 'mdi:chevron-up' : 'mdi:chevron-down'} class="h-4 w-4" />
+		</button>
+	</div>
+
+	{#if !collapsed}
+		<!-- Lista -->
+		<div class="max-h-[300px] overflow-y-auto overscroll-contain">
+			{#if $loadingVehicles}
+				<div class="flex h-20 items-center justify-center gap-2">
+					<div
+						class="h-5 w-5 animate-spin rounded-full border-2 border-white/10 border-t-sky-400"
+						aria-hidden="true"
+					></div>
+					<span class="text-xs text-white/40">Cargando…</span>
+				</div>
+			{:else if $vehicles.length === 0}
+				<p class="py-8 text-center text-xs text-white/30" role="status">
+					No hay unidades disponibles
+				</p>
+			{:else}
+				<ul class="m-0 list-none space-y-0.5 p-2" aria-label="Lista de unidades">
+					{#each $vehicles as v (v.id)}
+						{@const hasCoords = vehicleHasCoords(v)}
+						<li>
+							<button
+								type="button"
+								class="flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors hover:bg-white/[0.06] focus-visible:outline focus-visible:ring-2 focus-visible:ring-sky-400/40 disabled:cursor-not-allowed disabled:opacity-40"
+								disabled={!hasCoords}
+								on:click={() => selectVehicle(v)}
+								aria-label="Ver {v.name} en el mapa"
+							>
+								<div
+									class="h-2.5 w-2.5 shrink-0 rounded-full {getStatusDot(v)}"
+									aria-hidden="true"
+								></div>
+								<div class="min-w-0 flex-1">
+									<p class="m-0 truncate text-[13px] font-semibold text-white">{v.name}</p>
+									<p class="m-0 mt-0.5 text-[11px] text-white/40">
+										{v.driver || 'Sin conductor'}
+									</p>
+								</div>
+								<span class="shrink-0 text-[11px] font-semibold {getStatusColor(v)}">
+									{getStatusLabel(v)}
+								</span>
+							</button>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</div>
+
+		<!-- Footer -->
+		<div class="border-t border-white/[0.07] px-3 py-2">
+			<button
+				type="button"
+				class="flex w-full items-center justify-center gap-1.5 rounded-lg bg-white/[0.04] px-3 py-2 text-[11px] font-medium text-white/40 transition-colors hover:bg-white/[0.07] hover:text-white/65 disabled:opacity-50"
+				on:click={() => vehicleActions.loadVehiclePositions()}
+				disabled={$loadingPositions}
+				aria-busy={$loadingPositions}
+			>
+				<Icon
+					icon="mdi:refresh"
+					class="h-3.5 w-3.5 {$loadingPositions ? 'animate-spin' : ''}"
+					aria-hidden="true"
+				/>
+				{$loadingPositions ? 'Actualizando…' : 'Actualizar posiciones'}
+			</button>
+		</div>
+	{/if}
+</div>

--- a/src/lib/services/mapService.js
+++ b/src/lib/services/mapService.js
@@ -18,6 +18,8 @@ class MapService {
 		this._mobileZoneZoomLocked = false;
 		/** @type {string | null} */
 		this._openVehiclePopupId = null;
+		/** @type {((vehicle: any) => void) | null} */
+		this._onVehicleMarkerClick = null;
 		this.apiKey =
 			import.meta.env.VITE_GOOGLE_MAPS_API_KEY || 'AIzaSyC_NFPQKCUYcCq4WLTTOmSLnfQmRmPYE-8';
 	}
@@ -48,8 +50,27 @@ class MapService {
 		m.setMap(map);
 	}
 
-	_vehicleIconDataUrl(hexColor) {
-		const svg = `<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="16" cy="16" r="14" fill="${hexColor}" stroke="white" stroke-width="2"/><path d="M8 16h16M12 12h8M12 20h8" stroke="white" stroke-width="2" stroke-linecap="round"/></svg>`;
+	setOnVehicleMarkerClick(handler) {
+		this._onVehicleMarkerClick = typeof handler === 'function' ? handler : null;
+	}
+
+	_getVehicleGlyphPath(iconType) {
+		if (iconType?.includes('motorbike')) {
+			return '<path d="M9 18a2.2 2.2 0 1 0 0 4.4A2.2 2.2 0 0 0 9 18zm14 0a2.2 2.2 0 1 0 0 4.4A2.2 2.2 0 0 0 23 18zM10.7 19.2h4.8l2.5-3.6h2.7l1.3 2.1" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>';
+		}
+		if (
+			iconType?.includes('truck') ||
+			iconType?.includes('trailer') ||
+			iconType?.includes('backhoe')
+		) {
+			return '<path d="M7 18h11v-6H7v6zm11 0h4l2-2.2V14h-6v4zM10 22a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm10 0a2 2 0 1 0 0-4 2 2 0 0 0 0 4z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>';
+		}
+		return '<path d="M8 16h16M12 12h8M12 20h8" stroke="white" stroke-width="2" stroke-linecap="round"/>';
+	}
+
+	_vehicleIconDataUrl(hexColor, iconType = 'vehicle-car-sedan') {
+		const glyphPath = this._getVehicleGlyphPath(iconType);
+		const svg = `<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="16" cy="16" r="14" fill="${hexColor}" stroke="white" stroke-width="2"/>${glyphPath}</svg>`;
 		return 'data:image/svg+xml;charset=UTF-8,' + encodeURIComponent(svg);
 	}
 
@@ -68,10 +89,13 @@ class MapService {
 
 			const mapOptions = {
 				center: { lat: 19.4326, lng: -99.1332 },
-				zoom: 13,
+				zoom: 10,
 				mapTypeId: this.google.maps.MapTypeId.ROADMAP,
-				disableDefaultUI: false,
+				disableDefaultUI: true,
 				zoomControl: !isMobileLayout,
+				zoomControlOptions: {
+					position: this.google.maps.ControlPosition.LEFT_BOTTOM
+				},
 				fullscreenControl: false,
 				mapTypeControl: false,
 				streetViewControl: false,
@@ -156,14 +180,14 @@ class MapService {
 		}
 
 		const position = { lat: parseFloat(lat), lng: parseFloat(lng) };
-		const color = this.getVehicleColor(vehicle.status);
+		const color = this.getVehicleColor(vehicle);
 
 		const marker = new this.google.maps.Marker({
 			position,
 			map: null,
 			title: vehicle.name,
 			icon: {
-				url: this._vehicleIconDataUrl(color),
+				url: this._vehicleIconDataUrl(color, vehicle.icon_type),
 				scaledSize: new this.google.maps.Size(32, 32),
 				anchor: new this.google.maps.Point(16, 16)
 			},
@@ -178,6 +202,7 @@ class MapService {
 		infoWindow.setContent(this.createVehicleInfoContent(vehicle, infoWindow));
 
 		marker.addListener('click', () => {
+			this._onVehicleMarkerClick?.(vehicle);
 			this.openVehicleInfoWindow(vehicle, { refreshContent: false });
 		});
 
@@ -185,7 +210,10 @@ class MapService {
 		return marker;
 	}
 
-	getVehicleColor(status) {
+	getVehicleColor(vehicle) {
+		if (vehicle?.profile_color_hex) return vehicle.profile_color_hex;
+		if (vehicle?.profile_color?.startsWith?.('#')) return vehicle.profile_color;
+		const status = vehicle?.status;
 		switch (status) {
 			case 'active':
 				return '#10B981';
@@ -234,8 +262,15 @@ class MapService {
 		const lastUpdate = this._escapeHtml(vehicle.lastUpdateFormatted || 'No disponible');
 		const name = this._escapeHtml(vehicle.name || 'Unidad');
 		const driver = this._escapeHtml(vehicle.driver || 'No asignado');
+		const brandModel = [vehicle.brand, vehicle.model].filter(Boolean).join(' ').trim();
+		const brandModelText = this._escapeHtml(brandModel || 'Sin modelo');
+		const plateText = this._escapeHtml(vehicle.plate || '');
 		const location = this._escapeHtml(vehicle.location || 'Desconocida');
 		const deviceId = vehicle.deviceId ? this._escapeHtml(String(vehicle.deviceId)) : '';
+		// Telemetría igual que CommunicationDTO en Android/iOS
+		const mainVoltage = Number(vehicle.mainBatteryVoltage ?? vehicle.main_battery_voltage);
+		const backupVoltage = Number(vehicle.backupBatteryVoltage ?? vehicle.backup_battery_voltage);
+		const satellites = Number(vehicle.satellites);
 		const statusLabel = this._escapeHtml(this.getStatusText(vehicle.status));
 		const statusBadge = isDark
 			? this.getStatusBadgeStyleDark(vehicle.status)
@@ -256,6 +291,15 @@ class MapService {
 			const coordColor = isDark ? '#94a3b8' : '#64748b';
 			coordsBlock = `<p style="margin:0;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;font-size:10px;color:${coordColor};letter-spacing:0.02em;">${la}, ${lo}</p>`;
 		}
+
+		const hasMainVoltage = !Number.isNaN(mainVoltage) && mainVoltage > 0;
+		const hasBackupVoltage = !Number.isNaN(backupVoltage) && backupVoltage > 0;
+		const hasSatellites = !Number.isNaN(satellites) && satellites > 0;
+		const telemetryItems = [
+			hasMainVoltage ? `Principal ${mainVoltage.toFixed(1)}V` : null,
+			hasBackupVoltage ? `Respaldo ${backupVoltage.toFixed(1)}V` : null,
+			hasSatellites ? `${satellites} sat` : null
+		].filter(Boolean);
 
 		const divTop = isDark ? 'rgba(148,163,184,0.12)' : 'rgba(148,163,184,0.22)';
 		const deviceBlock = deviceId
@@ -330,6 +374,7 @@ class MapService {
 					<div style="flex:1;min-width:0;">
 						<h3 style="margin:0 0 6px 0;font-size:17px;font-weight:800;letter-spacing:-0.03em;color:${titleColor};line-height:1.2;">${name}</h3>
 						<p style="margin:0;font-size:12px;color:${mutedColor};font-weight:500;">${driver}</p>
+						<p style="margin:2px 0 0 0;font-size:11px;color:${mutedColor};font-weight:500;">${brandModelText}${plateText ? ` · ${plateText}` : ''}</p>
 					</div>
 					<span style="flex-shrink:0;display:inline-flex;align-items:center;padding:4px 10px;border-radius:9999px;font-size:10px;font-weight:800;letter-spacing:0.04em;text-transform:uppercase;${statusBadge}">${statusLabel}</span>
 				</div>
@@ -347,6 +392,7 @@ class MapService {
 					<div style="font-size:9px;font-weight:700;letter-spacing:0.07em;text-transform:uppercase;color:#64748b;margin-bottom:4px;">Ubicación</div>
 					<p style="margin:0;font-size:12px;font-weight:600;color:${locText};line-height:1.35;">${location}</p>
 				</div>
+				${telemetryItems.length > 0 ? `<div style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:10px;">${telemetryItems.map((label) => `<span style="display:inline-flex;align-items:center;padding:3px 7px;border-radius:999px;font-size:10px;font-weight:700;letter-spacing:0.02em;background:${isDark ? 'rgba(15,23,42,0.68)' : '#e2e8f0'};color:${isDark ? '#cbd5e1' : '#334155'};border:1px solid ${isDark ? 'rgba(148,163,184,0.2)' : 'rgba(100,116,139,0.22)'};">${label}</span>`).join('')}</div>` : ''}
 				${deviceBlock}
 				<div style="display:flex;align-items:center;justify-content:space-between;gap:8px;padding-top:10px;margin-top:4px;border-top:1px solid ${footerBorder};">
 					<span style="font-size:10px;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;color:#64748b;">Última señal</span>
@@ -496,7 +542,7 @@ class MapService {
 				existingMarkerData.popupVehicle = vehicle;
 
 				existingMarkerData.marker.setIcon({
-					url: this._vehicleIconDataUrl(this.getVehicleColor(vehicle.status)),
+					url: this._vehicleIconDataUrl(this.getVehicleColor(vehicle), vehicle.icon_type),
 					scaledSize: new this.google.maps.Size(32, 32),
 					anchor: new this.google.maps.Point(16, 16)
 				});
@@ -583,7 +629,7 @@ class MapService {
 		if (lat == null || lng == null || !this.map || !this.google) return;
 
 		this.map.setCenter({ lat: parseFloat(lat), lng: parseFloat(lng) });
-		this.map.setZoom(15);
+		this.map.setZoom(8);
 
 		if (!showPopup) return;
 

--- a/src/lib/services/positionService.js
+++ b/src/lib/services/positionService.js
@@ -46,6 +46,45 @@ class PositionService {
 			throw new Error(`Sin posición para dispositivo ${deviceId}`);
 		}
 		return match;
+		try {
+			const cacheKey = `position_${deviceId}`;
+			const cached = this.cache.get(cacheKey);
+
+			// Verificar cache
+			if (cached && Date.now() - cached.timestamp < this.cacheTimeout) {
+				return cached.data;
+			}
+
+			const response = await fetch(
+				`${COMM_API_URL}/api/v1/devices/${deviceId}/communications/latest`,
+				{
+					method: 'GET',
+					headers: {
+						'Content-Type': 'application/json'
+					}
+				}
+			);
+
+			if (!response.ok) {
+				throw new Error(`HTTP error! status: ${response.status}`);
+			}
+
+			const data = await response.json();
+
+			// Normalizar los datos
+			const normalizedData = this.normalizePositionData(data);
+
+			// Guardar en cache
+			this.cache.set(cacheKey, {
+				data: normalizedData,
+				timestamp: Date.now()
+			});
+
+			return normalizedData;
+		} catch (error) {
+			console.error(`Error obteniendo posición para dispositivo ${deviceId}:`, error);
+			throw error;
+		}
 	}
 
 	/**
@@ -77,9 +116,46 @@ class PositionService {
 	}
 
 	/**
-	 * Normaliza los datos de posición de la API
+	 * Helper: extrae string de múltiples keys posibles (como Android/iOS)
+	 */
+	_str(obj, ...keys) {
+		for (const k of keys) {
+			const v = obj?.[k];
+			if (v != null && v !== '') return String(v);
+		}
+		return null;
+	}
+
+	/**
+	 * Helper: extrae number de múltiples keys posibles (como Android/iOS)
+	 */
+	_num(obj, ...keys) {
+		for (const k of keys) {
+			const v = obj?.[k];
+			if (v == null) continue;
+			const n = typeof v === 'number' ? v : parseFloat(v);
+			if (!Number.isNaN(n)) return n;
+		}
+		return null;
+	}
+
+	/**
+	 * Helper: extrae int de múltiples keys posibles (como Android/iOS)
+	 */
+	_int(obj, ...keys) {
+		for (const k of keys) {
+			const v = obj?.[k];
+			if (v == null) continue;
+			const n = typeof v === 'number' ? Math.floor(v) : parseInt(v, 10);
+			if (!Number.isNaN(n)) return n;
+		}
+		return null;
+	}
+
+	/**
+	 * Normaliza los datos de comunicación de la API (igual que CommunicationDTO en Android/iOS)
 	 * @param {Object} rawData - Datos crudos de la API
-	 * @returns {Object} Datos normalizados
+	 * @returns {Object} Datos normalizados tipo CommunicationDTO
 	 */
 	normalizePositionData(rawData) {
 		const deviceId = rawData.device_id ?? rawData.deviceId;
@@ -92,6 +168,81 @@ class PositionService {
 		if (!deviceId || Number.isNaN(latitude) || Number.isNaN(longitude)) {
 			throw new Error('Posición incompleta');
 		}
+
+		const attrs = rawData?.attributes || {};
+
+		// Extraer campos exactamente como Android/iOS CommunicationDTO
+		const deviceId = this._str(rawData, 'deviceId', 'device_id', 'DEVICE_ID') || '';
+		const latitude = this._num(rawData, 'latitude', 'LATITUD') ?? 0;
+		const longitude = this._num(rawData, 'longitude', 'LONGITUD') ?? 0;
+		const speed = this._num(rawData, 'speed', 'SPEED');
+		const course = this._num(rawData, 'course', 'COURSE');
+		const gpsDatetime = this._str(rawData, 'gpsDatetime', 'gps_datetime', 'GPS_DATETIME');
+		const gpsEpoch = this._int(rawData, 'gpsEpoch', 'gps_epoch', 'GPS_EPOCH');
+
+		// mainBatteryVoltage: buscar en root y luego en attributes (igual que Android/iOS)
+		let mainBatteryVoltage = this._num(
+			rawData,
+			'mainBatteryVoltage',
+			'main_battery_voltage',
+			'MAIN_VOLTAGE',
+			'main_voltage',
+			'battery_voltage',
+			'battery'
+		);
+		if (mainBatteryVoltage == null) {
+			mainBatteryVoltage = this._num(
+				attrs,
+				'main_battery_voltage',
+				'MAIN_VOLTAGE',
+				'main_voltage',
+				'battery_voltage',
+				'battery',
+				'voltage',
+				'io220',
+				'power'
+			);
+		}
+
+		// backupBatteryVoltage: buscar en root y luego en attributes
+		let backupBatteryVoltage = this._num(
+			rawData,
+			'backupBatteryVoltage',
+			'backup_battery_voltage',
+			'BACKUP_VOLTAGE',
+			'backup_voltage',
+			'battery_level'
+		);
+		if (backupBatteryVoltage == null) {
+			backupBatteryVoltage = this._num(
+				attrs,
+				'backup_battery_voltage',
+				'BACKUP_VOLTAGE',
+				'backup_voltage',
+				'battery_level',
+				'batteryLevel',
+				'io219'
+			);
+		}
+
+		const odometer = this._int(rawData, 'odometer', 'ODOMETER');
+		const engineStatus = this._str(rawData, 'engineStatus', 'engine_status', 'ENGINE_STATUS');
+		const fixStatus = this._str(rawData, 'fixStatus', 'fix_status', 'FIX_STATUS');
+		// "stellites" es un typo conocido del firmware
+		const satellites = this._int(rawData, 'satellites', 'stellites', 'SATELLITES');
+		const rxLvl = this._int(rawData, 'rxLvl', 'rx_lvl', 'RX_LVL');
+		const networkStatus = this._str(rawData, 'networkStatus', 'network_status', 'NETWORK_STATUS');
+		const msgClass = this._str(rawData, 'msgClass', 'msg_class', 'MSG_CLASS');
+		const deliveryType = this._str(rawData, 'deliveryType', 'delivery_type', 'DELIVERY_TYPE');
+		const receivedEpoch = this._int(rawData, 'receivedEpoch', 'received_epoch');
+		const receivedAt = this._str(rawData, 'receivedAt', 'received_at');
+		const alertType = this._str(rawData, 'alertType', 'alert_type', 'ALERT_TYPE');
+
+		// lastUpdate: preferir gps_datetime, luego received_at, luego timelastposition
+		const lastUpdate = gpsDatetime || receivedAt || rawData?.timelastposition || null;
+
+		// isOnline: basado en engineStatus (ON = online) como en las apps nativas
+		const isOnline = engineStatus?.toUpperCase() === 'ON';
 
 		return {
 			deviceId: String(deviceId),

--- a/src/lib/services/positionService.js
+++ b/src/lib/services/positionService.js
@@ -158,17 +158,6 @@ class PositionService {
 	 * @returns {Object} Datos normalizados tipo CommunicationDTO
 	 */
 	normalizePositionData(rawData) {
-		const deviceId = rawData.device_id ?? rawData.deviceId;
-		const latitude = parseFloat(rawData.latitude ?? rawData.lat);
-		const longitude = parseFloat(rawData.longitude ?? rawData.lng);
-		const lastUpdate =
-			rawData.gps_datetime ?? rawData.received_at ?? rawData.timelastposition ?? null;
-		const engineStatus = rawData.engine_status ?? rawData.status;
-
-		if (!deviceId || Number.isNaN(latitude) || Number.isNaN(longitude)) {
-			throw new Error('Posición incompleta');
-		}
-
 		const attrs = rawData?.attributes || {};
 
 		// Extraer campos exactamente como Android/iOS CommunicationDTO

--- a/src/lib/stores/vehicleStore.js
+++ b/src/lib/stores/vehicleStore.js
@@ -7,6 +7,7 @@ import { formatLastUpdate } from '$lib/utils/vehicleUtils.js';
 // Estado principal de vehículos
 export const vehicles = writable([]);
 export const selectedVehicles = writable([]);
+export const activeUnitId = writable(null);
 export const loadingVehicles = writable(false);
 export const vehiclePositions = writable(new Map());
 export const loadingPositions = writable(false);
@@ -14,6 +15,11 @@ export const loadingPositions = writable(false);
 export const activeVehicles = derived(vehicles, ($vehicles) =>
 	$vehicles.filter((vehicle) => vehicle.status === 'active')
 );
+
+export const activeUnit = derived([vehicles, activeUnitId], ([$vehicles, $activeUnitId]) => {
+	if (!$activeUnitId) return null;
+	return $vehicles.find((vehicle) => vehicle.id === $activeUnitId) || null;
+});
 
 // Store derivado para contar vehículos seleccionados
 export const selectedVehicleCount = derived(selectedVehicles, ($selected) => $selected.length);
@@ -310,5 +316,9 @@ export const vehicleActions = {
 		await apiService.deleteVehicle(vehicleId);
 		vehicles.update((list) => list.filter((v) => v.id !== vehicleId));
 		selectedVehicles.update((list) => list.filter((id) => id !== vehicleId));
+	},
+
+	setActiveUnit(unitId) {
+		activeUnitId.set(unitId);
 	}
 };

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -16,7 +16,12 @@
 		zoneUiToast
 	} from '$lib/stores/h3Store.js';
 	import { theme } from '$lib/stores/themeStore.js';
-	import { vehicles, vehicleActions, loadingVehicles } from '$lib/stores/vehicleStore.js';
+	import {
+		vehicles,
+		activeUnit,
+		vehicleActions,
+		loadingVehicles
+	} from '$lib/stores/vehicleStore.js';
 	import { getStatusText, getStatusPillClass } from '$lib/utils/vehicleUtils.js';
 	import { mapService } from '$lib/services/mapService.js';
 	import { alertActions } from '$lib/stores/alertStore.js';
@@ -33,6 +38,8 @@
 	import TabAlertas from '$lib/components/TabAlertas.svelte';
 	import TabAjustes from '$lib/components/TabAjustes.svelte';
 	import ZonasPanel from '$lib/components/ZonasPanel.svelte';
+	import TrackingContextPanel from '$lib/components/TrackingContextPanel.svelte';
+	import VehicleListPanel from '$lib/components/VehicleListPanel.svelte';
 
 	let isLoading = true;
 	let userData = null;
@@ -40,6 +47,7 @@
 	let showUserMenu = false;
 	let showMobileUnitsSheet = false;
 	let prevMobileTab = 'seguimiento';
+	let trackingPanelView = 'unit-info';
 
 	let openDrawer = ''; // '' | 'informes' | 'configuracion'
 
@@ -112,6 +120,15 @@
 		configSidebarItems.find((item) => item.id === activeConfigSection)?.label ??
 		'Configuración';
 
+	function onTrackingPanelViewChange(nextView) {
+		trackingPanelView = nextView;
+	}
+
+	function centerOnActiveUnit() {
+		if (!$activeUnit) return;
+		mapService.centerOnVehicle($activeUnit);
+	}
+
 	function handleBodyClick(e) {
 		if (!e.target.closest('[data-dashboard-user-menu]')) showUserMenu = false;
 	}
@@ -170,8 +187,11 @@
 	}
 
 	function onMobileVehicleRowClick(v) {
-		if (!mobileVehicleHasCoords(v)) return;
-		mapService.centerOnVehicle(v);
+		vehicleActions.setActiveUnit(v.id);
+		trackingPanelView = 'unit-info';
+		if (mobileVehicleHasCoords(v)) {
+			mapService.centerOnVehicle(v);
+		}
 		closeMobileUnitsSheet();
 	}
 
@@ -484,6 +504,27 @@
 			<ZonasPanel variant="desktop" useDesktopOverlayStore={true} />
 		{/if}
 
+		<!-- PR-04: TrackingContextPanel flotante para desktop/tablet -->
+		{#if $activeUnit}
+			<div
+				class="pointer-events-none fixed bottom-24 right-4 z-[100] hidden w-[340px] md:block"
+			>
+				<div class="pointer-events-auto overflow-hidden rounded-2xl shadow-2xl">
+					<TrackingContextPanel
+						unit={$activeUnit}
+						units={$vehicles}
+						panelView={trackingPanelView}
+						onPanelViewChange={onTrackingPanelViewChange}
+						onSelectUnit={(u) => {
+							vehicleActions.setActiveUnit(u.id);
+							mapService.centerOnVehicle(u);
+						}}
+						onCenterUnit={centerOnActiveUnit}
+					/>
+				</div>
+			</div>
+		{/if}
+
 		{#if $zoneUiToast}
 			<div
 				class="pointer-events-none fixed left-1/2 top-[max(5.5rem,calc(env(safe-area-inset-top,0px)+4.5rem))] z-[200] flex w-full max-w-[min(92vw,22rem)] -translate-x-1/2 justify-center px-4 sm:left-[calc(50%+36px)]"
@@ -497,7 +538,7 @@
 			</div>
 		{/if}
 
-		{#if $activeTab === 'seguimiento'}
+		{#if $activeTab === 'seguimiento' && (!$activeUnit || showMobileUnitsSheet)}
 			<div
 				class="pointer-events-none fixed inset-x-0 bottom-[calc(56px+env(safe-area-inset-bottom,0px)+2px)] z-[220] flex sm:hidden"
 				aria-label="Panel de unidades"
@@ -582,8 +623,7 @@
 										<li>
 											<button
 												type="button"
-												class="flex w-full cursor-pointer items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 px-3.5 py-3 text-left transition-colors hover:border-cyan-400/50 hover:bg-cyan-50/80 focus-visible:outline focus-visible:ring-2 focus-visible:ring-cyan-400/45 disabled:cursor-not-allowed disabled:opacity-45 dark:border-white/[0.08] dark:bg-white/[0.04] dark:hover:border-cyan-400/30 dark:hover:bg-white/[0.07]"
-												disabled={!mobileVehicleHasCoords(v)}
+												class="flex w-full cursor-pointer items-center gap-3 rounded-xl border border-slate-200 bg-slate-50 px-3.5 py-3 text-left transition-colors hover:border-cyan-400/50 hover:bg-cyan-50/80 focus-visible:outline focus-visible:ring-2 focus-visible:ring-cyan-400/45 dark:border-white/[0.08] dark:bg-white/[0.04] dark:hover:border-cyan-400/30 dark:hover:bg-white/[0.07]"
 												on:click={() => onMobileVehicleRowClick(v)}
 												aria-label="Ver {v.name} en el mapa"
 											>
@@ -670,6 +710,26 @@
 			</div>
 		{/if}
 	</main>
+
+	{#if $activeTab === 'seguimiento' && $activeUnit && !showMobileUnitsSheet}
+		<div
+			class="fixed bottom-[calc(56px+env(safe-area-inset-bottom,0px)+8px)] left-2 right-2 z-[55] sm:hidden"
+			transition:fly={{ y: 20, duration: 200, easing: cubicOut }}
+		>
+			<TrackingContextPanel
+				unit={$activeUnit}
+				units={$vehicles}
+				panelView={trackingPanelView}
+				onPanelViewChange={onTrackingPanelViewChange}
+				onCenterUnit={centerOnActiveUnit}
+				onSelectUnit={(id) => {
+					vehicleActions.setActiveUnit(id);
+					const v = $vehicles.find(u => u.id === id);
+					if (v) mapService.centerOnVehicle(v);
+				}}
+			/>
+		</div>
+	{/if}
 
 	<div class="sm:hidden" aria-hidden="true">
 		<BottomTabBar />

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -506,9 +506,7 @@
 
 		<!-- PR-04: TrackingContextPanel flotante para desktop/tablet -->
 		{#if $activeUnit}
-			<div
-				class="pointer-events-none fixed bottom-24 right-4 z-[100] hidden w-[340px] md:block"
-			>
+			<div class="pointer-events-none fixed bottom-24 right-4 z-[100] hidden w-[340px] md:block">
 				<div class="pointer-events-auto overflow-hidden rounded-2xl shadow-2xl">
 					<TrackingContextPanel
 						unit={$activeUnit}
@@ -724,7 +722,7 @@
 				onCenterUnit={centerOnActiveUnit}
 				onSelectUnit={(id) => {
 					vehicleActions.setActiveUnit(id);
-					const v = $vehicles.find(u => u.id === id);
+					const v = $vehicles.find((u) => u.id === id);
 					if (v) mapService.centerOnVehicle(v);
 				}}
 			/>


### PR DESCRIPTION
## Summary

- Add contextual tracking panel that displays real-time unit telemetry (battery, satellites, engine status) matching Android/iOS CommunicationDTO structure
- Implement mobile-first tracking UI with bottom sheet for unit selection and floating panel for active unit details
- Add desktop/tablet floating panel in bottom-right corner when a unit is selected
- Normalize position data to match native apps' CommunicationDTO format (mainBatteryVoltage, backupBatteryVoltage, satellites, engineStatus, gpsDatetime)

## Changes

- **New components:**
  - `TrackingContextPanel.svelte` - Contextual panel with unit info, quick actions (Trips, Events, Details, Share), and unit picker
  - `VehicleListPanel.svelte` - Reusable vehicle list component

- **Enhanced services:**
  - `positionService.js` - Full CommunicationDTO field extraction with fallback lookups
  - `mapService.js` - Added `setOnVehicleMarkerClick` callback, adjusted zoom level to 8

- **Store updates:**
  - `vehicleStore.js` - Added `activeUnitId` (writable) and `activeUnit` (derived) stores with `setActiveUnit` action

- **Dashboard integration:**
  - Mobile: Shows tracking panel when unit selected, hides "select a unit" prompt
  - Desktop: Floating panel in bottom-right corner
  - Map marker clicks now set active unit