### PR TITLE
feat(web): add trip history with playback and alerts visualization

### DIFF
--- a/src/lib/components/TripDetailView.svelte
+++ b/src/lib/components/TripDetailView.svelte
@@ -1,0 +1,202 @@
+<script>
+	import Icon from '@iconify/svelte';
+	import { mapService } from '$lib/services/mapService.js';
+
+	export let trip = null;
+	export let onBack = () => {};
+	export let onClose = () => {};
+
+	let isPlaying = false;
+	let showAlerts = false;
+	let playbackProgress = 0;
+
+	$: distance = trip?.distance_km != null ? `${trip.distance_km.toFixed(1)} km` : '--';
+	$: duration = formatDuration(trip?.duration_minutes);
+	$: alertsCount = trip?.alerts?.length || 0;
+	$: pointsCount = trip?.points?.length || 0;
+
+	function formatDuration(minutes) {
+		if (minutes == null) return '--';
+		const m = Math.round(minutes);
+		return `${m} min`;
+	}
+
+	function togglePlay() {
+		if (isPlaying) {
+			mapService.pauseTripPlayback();
+			isPlaying = false;
+		} else {
+			if (!trip?.points?.length) return;
+			mapService.startTripPlayback(trip.points, {
+				onProgress: (progress) => {
+					playbackProgress = progress;
+				},
+				onComplete: () => {
+					isPlaying = false;
+					playbackProgress = 0;
+				}
+			});
+			isPlaying = true;
+		}
+	}
+
+	function stopPlayback() {
+		mapService.stopTripPlayback();
+		isPlaying = false;
+		playbackProgress = 0;
+	}
+
+	function toggleAlerts() {
+		showAlerts = !showAlerts;
+		if (showAlerts && trip?.alerts?.length) {
+			mapService.showTripAlerts(trip.alerts);
+		} else {
+			mapService.hideTripAlerts();
+		}
+	}
+
+	function centerOnRoute() {
+		if (trip?.points?.length) {
+			mapService.fitBoundsToPoints(trip.points);
+		}
+	}
+
+	function handleBack() {
+		stopPlayback();
+		mapService.hideTripAlerts();
+		onBack();
+	}
+
+	function handleClose() {
+		stopPlayback();
+		mapService.hideTripAlerts();
+		mapService.clearTripRoute();
+		onClose();
+	}
+</script>
+
+<div class="flex h-full flex-col bg-[#0c1829]">
+	<!-- Header -->
+	<div class="flex items-center justify-between px-4 py-3">
+		<button
+			type="button"
+			class="flex h-10 w-10 items-center justify-center rounded-full text-white/70 hover:bg-white/10"
+			on:click={handleBack}
+			aria-label="Volver"
+		>
+			<Icon icon="mdi:chevron-left" width={28} />
+		</button>
+		<h2 class="text-lg font-semibold text-white">Detalle del Trayecto</h2>
+		<button
+			type="button"
+			class="flex h-10 w-10 items-center justify-center rounded-full text-white/70 hover:bg-white/10"
+			on:click={handleClose}
+			aria-label="Cerrar"
+		>
+			<Icon icon="mdi:close" width={24} />
+		</button>
+	</div>
+
+	<!-- Playback Controls -->
+	<div class="px-4 pb-4">
+		<div class="flex items-center gap-3">
+			<div class="flex-1">
+				<p
+					class="text-xs font-semibold uppercase tracking-wide {isPlaying
+						? 'text-cyan-400'
+						: 'text-white/50'}"
+				>
+					{isPlaying ? 'Reproduciendo' : 'Trayecto'}
+				</p>
+				<p class="text-sm text-white/70">Controles en vivo</p>
+			</div>
+
+			<!-- Play/Pause -->
+			<button
+				type="button"
+				class="flex h-12 w-12 items-center justify-center rounded-full {isPlaying
+					? 'bg-cyan-500'
+					: 'bg-white/10'} transition-colors"
+				on:click={togglePlay}
+				aria-label={isPlaying ? 'Pausar' : 'Reproducir'}
+			>
+				<Icon icon={isPlaying ? 'mdi:pause' : 'mdi:play'} width={24} class="text-white" />
+			</button>
+
+			<!-- Stop -->
+			{#if isPlaying || playbackProgress > 0}
+				<button
+					type="button"
+					class="flex h-12 w-12 items-center justify-center rounded-full bg-red-500 transition-colors"
+					on:click={stopPlayback}
+					aria-label="Detener"
+				>
+					<Icon icon="mdi:stop" width={24} class="text-white" />
+				</button>
+			{/if}
+
+			<!-- Alerts Toggle -->
+			<button
+				type="button"
+				class="flex h-12 w-12 items-center justify-center rounded-full {showAlerts
+					? 'bg-amber-500'
+					: 'bg-white/10'} transition-colors"
+				on:click={toggleAlerts}
+				aria-label={showAlerts ? 'Ocultar alertas' : 'Mostrar alertas'}
+			>
+				<Icon icon="mdi:alert" width={24} class="text-white" />
+			</button>
+
+			<!-- Center -->
+			<button
+				type="button"
+				class="flex h-12 w-12 items-center justify-center rounded-full bg-white/10 transition-colors hover:bg-white/20"
+				on:click={centerOnRoute}
+				aria-label="Centrar en ruta"
+			>
+				<Icon icon="mdi:crosshairs-gps" width={24} class="text-white" />
+			</button>
+		</div>
+
+		<!-- Progress bar -->
+		{#if isPlaying || playbackProgress > 0}
+			<div class="mt-3 h-1 overflow-hidden rounded-full bg-white/10">
+				<div
+					class="h-full bg-cyan-400 transition-all duration-100"
+					style="width: {playbackProgress * 100}%"
+				></div>
+			</div>
+		{/if}
+	</div>
+
+	<!-- Stats Grid -->
+	<div class="grid grid-cols-2 gap-3 px-4 pb-4">
+		<!-- Distance -->
+		<div class="flex flex-col items-center justify-center rounded-2xl bg-white/5 py-4">
+			<Icon icon="mdi:swap-horizontal" width={28} class="text-cyan-400" />
+			<p class="mt-2 text-xl font-bold text-white">{distance}</p>
+			<p class="text-xs text-white/50">Distancia</p>
+		</div>
+
+		<!-- Duration -->
+		<div class="flex flex-col items-center justify-center rounded-2xl bg-white/5 py-4">
+			<Icon icon="mdi:clock-outline" width={28} class="text-cyan-400" />
+			<p class="mt-2 text-xl font-bold text-white">{duration}</p>
+			<p class="text-xs text-white/50">Duración</p>
+		</div>
+
+		<!-- Alerts -->
+		<div class="flex flex-col items-center justify-center rounded-2xl bg-white/5 py-4">
+			<Icon icon="mdi:alert-outline" width={28} class="text-amber-400" />
+			<p class="mt-2 text-xl font-bold text-white">{alertsCount}</p>
+			<p class="text-xs text-white/50">Alertas</p>
+		</div>
+
+		<!-- Points -->
+		<div class="flex flex-col items-center justify-center rounded-2xl bg-white/5 py-4">
+			<Icon icon="mdi:map-marker-multiple" width={28} class="text-emerald-400" />
+			<p class="mt-2 text-xl font-bold text-white">{pointsCount}</p>
+			<p class="text-xs text-white/50">Puntos</p>
+		</div>
+	</div>
+</div>

--- a/src/lib/components/TripHistoryPanel.svelte
+++ b/src/lib/components/TripHistoryPanel.svelte
@@ -1,0 +1,191 @@
+<script>
+	import Icon from '@iconify/svelte';
+	import {
+		trips,
+		selectedTrip,
+		loadingTrips,
+		tripError,
+		tripActions
+	} from '$lib/stores/tripStore.js';
+	import { mapService } from '$lib/services/mapService.js';
+	import TripDetailView from './TripDetailView.svelte';
+
+	export let unit = null;
+	export let onBack = () => {};
+
+	let selectedDate = new Date().toISOString().split('T')[0];
+	let hasMore = false;
+	let cursor = null;
+	let showDetail = false;
+	let loadingDetail = false;
+
+	function formatDuration(minutes) {
+		if (minutes == null) return '--';
+		const h = Math.floor(minutes / 60);
+		const m = Math.round(minutes % 60);
+		if (h > 0) return `${h}h ${m}m`;
+		return `${m} min`;
+	}
+
+	function formatDistance(km) {
+		if (km == null) return '--';
+		return `${km.toFixed(1)} km`;
+	}
+
+	function formatTime(dateStr) {
+		if (!dateStr) return '--';
+		const d = new Date(dateStr);
+		if (Number.isNaN(d.getTime())) return '--';
+		return d.toLocaleTimeString('es-MX', { hour: '2-digit', minute: '2-digit' });
+	}
+
+	async function loadTrips() {
+		if (!unit?.id) return;
+
+		const dateStart = new Date(selectedDate);
+		dateStart.setHours(0, 0, 0, 0);
+		const dateEnd = new Date(selectedDate);
+		dateEnd.setHours(23, 59, 59, 999);
+
+		const result = await tripActions.loadTripsForUnit(unit.id, {
+			dateRange: { start: dateStart, end: dateEnd }
+		});
+
+		hasMore = result.hasMore;
+		cursor = result.cursor;
+	}
+
+	async function selectTrip(trip) {
+		loadingDetail = true;
+		tripActions.selectTrip(trip.trip_id);
+
+		const detail = await tripActions.loadTripDetail(trip.trip_id, {
+			includePoints: true,
+			includeAlerts: true
+		});
+
+		if (detail?.points?.length) {
+			mapService.drawTripRoute(detail.points);
+			mapService.fitBoundsToPoints(detail.points);
+		}
+
+		loadingDetail = false;
+		showDetail = true;
+	}
+
+	function handleBackFromDetail() {
+		showDetail = false;
+		mapService.clearTripRoute();
+		mapService.hideTripAlerts();
+		mapService.stopTripPlayback();
+	}
+
+	function handleClose() {
+		tripActions.clearTrips();
+		mapService.clearTripRoute();
+		mapService.hideTripAlerts();
+		mapService.stopTripPlayback();
+		onBack();
+	}
+
+	function handleBack() {
+		tripActions.clearTrips();
+		mapService.clearTripRoute();
+		onBack();
+	}
+
+	function handleDateChange() {
+		tripActions.clearTrips();
+		mapService.clearTripRoute();
+		showDetail = false;
+		loadTrips();
+	}
+
+	$: if (unit?.id) {
+		loadTrips();
+	}
+</script>
+
+{#if showDetail && $selectedTrip}
+	<TripDetailView trip={$selectedTrip} onBack={handleBackFromDetail} onClose={handleClose} />
+{:else}
+	<div class="flex h-full flex-col">
+		<div class="flex items-center gap-2 border-b border-white/10 px-3 py-2">
+			<button
+				type="button"
+				class="flex h-8 w-8 items-center justify-center rounded-lg text-white/60 hover:bg-white/10"
+				on:click={handleBack}
+				aria-label="Volver"
+			>
+				<Icon icon="mdi:arrow-left" width={20} />
+			</button>
+			<div class="flex-1">
+				<p class="m-0 text-sm font-semibold text-white">Trayectos</p>
+				<p class="m-0 text-[11px] text-white/50">{unit?.name || 'Unidad'}</p>
+			</div>
+		</div>
+
+		<div class="border-b border-white/10 px-3 py-2">
+			<input
+				type="date"
+				bind:value={selectedDate}
+				on:change={handleDateChange}
+				class="w-full rounded-lg border border-white/15 bg-white/5 px-3 py-2 text-sm text-white"
+			/>
+		</div>
+
+		<div class="flex-1 overflow-y-auto">
+			{#if $loadingTrips || loadingDetail}
+				<div class="flex h-32 items-center justify-center">
+					<div
+						class="h-6 w-6 animate-spin rounded-full border-2 border-cyan-500/30 border-t-cyan-500"
+					></div>
+				</div>
+			{:else if $tripError}
+				<div class="flex h-32 flex-col items-center justify-center gap-2 px-4 text-center">
+					<Icon icon="mdi:alert-circle-outline" width={28} class="text-red-400" />
+					<p class="m-0 text-xs text-white/50">{$tripError}</p>
+				</div>
+			{:else if $trips.length === 0}
+				<div class="flex h-32 flex-col items-center justify-center gap-2 px-4 text-center">
+					<Icon icon="mdi:map-marker-path" width={28} class="text-white/25" />
+					<p class="m-0 text-xs text-white/50">Sin trayectos para esta fecha</p>
+				</div>
+			{:else}
+				<ul class="m-0 list-none space-y-2 p-3">
+					{#each $trips as trip (trip.trip_id)}
+						<li>
+							<button
+								type="button"
+								class="flex w-full items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-left transition-colors hover:border-cyan-400/30 hover:bg-white/10"
+								on:click={() => selectTrip(trip)}
+							>
+								<div
+									class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-cyan-400/15"
+								>
+									<Icon icon="mdi:clock-outline" width={20} class="text-cyan-400" />
+								</div>
+								<div class="min-w-0 flex-1">
+									<p class="m-0 text-[15px] font-semibold text-white">
+										{formatTime(trip.start_timestamp)} - {formatTime(trip.end_timestamp)}
+									</p>
+									<div class="mt-1 flex items-center gap-4 text-xs text-white/50">
+										<span class="flex items-center gap-1">
+											<Icon icon="mdi:swap-horizontal" width={14} />
+											{formatDistance(trip.distance_km)}
+										</span>
+										<span class="flex items-center gap-1">
+											<Icon icon="mdi:clock-outline" width={14} />
+											{formatDuration(trip.duration_minutes)}
+										</span>
+									</div>
+								</div>
+								<Icon icon="mdi:chevron-right" width={20} class="text-white/30" />
+							</button>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</div>
+	</div>
+{/if}

--- a/src/lib/services/mapService.js
+++ b/src/lib/services/mapService.js
@@ -617,7 +617,12 @@ class MapService {
 		});
 
 		if (hasValidCoordinates) {
-			this.map.fitBounds(bounds);
+			this.map.fitBounds(bounds, { padding: 80 });
+			this.google.maps.event.addListenerOnce(this.map, 'idle', () => {
+				if (this.map.getZoom() > 12) {
+					this.map.setZoom(12);
+				}
+			});
 		}
 	}
 
@@ -707,6 +712,269 @@ class MapService {
 			minZoom: 0,
 			maxZoom: 22
 		});
+	}
+
+	// ── Trip Route (Polyline) ─────────────────────────────────────────────────
+
+	/** @type {google.maps.Polyline | null} */
+	_tripPolyline = null;
+	/** @type {google.maps.Marker | null} */
+	_tripStartMarker = null;
+	/** @type {google.maps.Marker | null} */
+	_tripEndMarker = null;
+
+	/**
+	 * Dibuja la ruta del trayecto en el mapa
+	 * @param {Array<{lat: number, lon: number}>} points
+	 */
+	drawTripRoute(points) {
+		if (!this.map || !this.google || !points?.length) return;
+
+		this.clearTripRoute();
+
+		const path = points.map((p) => ({
+			lat: parseFloat(p.lat),
+			lng: parseFloat(p.lon ?? p.lng)
+		}));
+
+		this._tripPolyline = new this.google.maps.Polyline({
+			path,
+			geodesic: true,
+			strokeColor: '#10b981',
+			strokeOpacity: 1,
+			strokeWeight: 5,
+			map: this.map
+		});
+
+		if (path.length > 0) {
+			this._tripStartMarker = new this.google.maps.Marker({
+				position: path[0],
+				map: this.map,
+				icon: {
+					path: this.google.maps.SymbolPath.CIRCLE,
+					scale: 8,
+					fillColor: '#22c55e',
+					fillOpacity: 1,
+					strokeColor: '#fff',
+					strokeWeight: 2
+				},
+				title: 'Inicio'
+			});
+		}
+
+		if (path.length > 1) {
+			this._tripEndMarker = new this.google.maps.Marker({
+				position: path[path.length - 1],
+				map: this.map,
+				icon: {
+					path: this.google.maps.SymbolPath.CIRCLE,
+					scale: 8,
+					fillColor: '#ef4444',
+					fillOpacity: 1,
+					strokeColor: '#fff',
+					strokeWeight: 2
+				},
+				title: 'Fin'
+			});
+		}
+	}
+
+	/** Limpia la ruta del trayecto del mapa */
+	clearTripRoute() {
+		if (this._tripPolyline) {
+			this._tripPolyline.setMap(null);
+			this._tripPolyline = null;
+		}
+		if (this._tripStartMarker) {
+			this._tripStartMarker.setMap(null);
+			this._tripStartMarker = null;
+		}
+		if (this._tripEndMarker) {
+			this._tripEndMarker.setMap(null);
+			this._tripEndMarker = null;
+		}
+	}
+
+	/**
+	 * Ajusta el mapa para mostrar todos los puntos del trayecto
+	 * @param {Array<{lat: number, lon: number}>} points
+	 */
+	fitBoundsToPoints(points) {
+		if (!this.map || !this.google || !points?.length) return;
+
+		const bounds = new this.google.maps.LatLngBounds();
+		for (const p of points) {
+			bounds.extend({
+				lat: parseFloat(p.lat),
+				lng: parseFloat(p.lon ?? p.lng)
+			});
+		}
+		this.map.fitBounds(bounds, { padding: 50 });
+	}
+
+	// ── Trip Playback ─────────────────────────────────────────────────────────
+
+	/** @type {google.maps.Marker | null} */
+	_playbackMarker = null;
+	/** @type {number | null} */
+	_playbackInterval = null;
+	/** @type {number} */
+	_playbackIndex = 0;
+	/** @type {Array<{lat: number, lng: number}>} */
+	_playbackPath = [];
+	/** @type {((progress: number) => void) | null} */
+	_onPlaybackProgress = null;
+	/** @type {(() => void) | null} */
+	_onPlaybackComplete = null;
+	/** @type {boolean} */
+	_playbackPaused = false;
+
+	/**
+	 * Inicia la reproducción animada del trayecto
+	 * @param {Array<{lat: number, lon: number}>} points
+	 * @param {{ onProgress?: (progress: number) => void, onComplete?: () => void }} callbacks
+	 */
+	startTripPlayback(points, callbacks = {}) {
+		if (!this.map || !this.google || !points?.length) return;
+
+		this.stopTripPlayback();
+
+		this._playbackPath = points.map((p) => ({
+			lat: parseFloat(p.lat),
+			lng: parseFloat(p.lon ?? p.lng)
+		}));
+		this._playbackIndex = 0;
+		this._onPlaybackProgress = callbacks.onProgress || null;
+		this._onPlaybackComplete = callbacks.onComplete || null;
+		this._playbackPaused = false;
+
+		this._playbackMarker = new this.google.maps.Marker({
+			position: this._playbackPath[0],
+			map: this.map,
+			icon: {
+				path: this.google.maps.SymbolPath.CIRCLE,
+				scale: 10,
+				fillColor: '#ef4444',
+				fillOpacity: 1,
+				strokeColor: '#fff',
+				strokeWeight: 3
+			},
+			zIndex: 1000,
+			title: 'Posición actual'
+		});
+
+		const PLAYBACK_SPEED_MS = 400;
+
+		this._playbackInterval = setInterval(() => {
+			if (this._playbackPaused) return;
+
+			this._playbackIndex++;
+
+			if (this._playbackIndex >= this._playbackPath.length) {
+				this.stopTripPlayback();
+				this._onPlaybackComplete?.();
+				return;
+			}
+
+			const pos = this._playbackPath[this._playbackIndex];
+			this._playbackMarker?.setPosition(pos);
+			this.map.panTo(pos);
+
+			const progress = this._playbackIndex / (this._playbackPath.length - 1);
+			this._onPlaybackProgress?.(progress);
+		}, PLAYBACK_SPEED_MS);
+	}
+
+	/** Pausa la reproducción */
+	pauseTripPlayback() {
+		this._playbackPaused = true;
+	}
+
+	/** Reanuda la reproducción */
+	resumeTripPlayback() {
+		this._playbackPaused = false;
+	}
+
+	/** Detiene y resetea la reproducción */
+	stopTripPlayback() {
+		if (this._playbackInterval) {
+			clearInterval(this._playbackInterval);
+			this._playbackInterval = null;
+		}
+		if (this._playbackMarker) {
+			this._playbackMarker.setMap(null);
+			this._playbackMarker = null;
+		}
+		this._playbackIndex = 0;
+		this._playbackPath = [];
+		this._playbackPaused = false;
+	}
+
+	// ── Trip Alerts ───────────────────────────────────────────────────────────
+
+	/** @type {google.maps.Marker[]} */
+	_tripAlertMarkers = [];
+
+	/**
+	 * Muestra marcadores de alertas en el mapa
+	 * @param {Array<{lat: number, lon: number, type: string}>} alerts
+	 */
+	showTripAlerts(alerts) {
+		if (!this.map || !this.google || !alerts?.length) return;
+
+		this.hideTripAlerts();
+
+		for (const alert of alerts) {
+			if (alert.lat == null || alert.lon == null) continue;
+
+			const marker = new this.google.maps.Marker({
+				position: {
+					lat: parseFloat(alert.lat),
+					lng: parseFloat(alert.lon ?? alert.lng)
+				},
+				map: this.map,
+				icon: {
+					path: this.google.maps.SymbolPath.CIRCLE,
+					scale: 8,
+					fillColor: '#f59e0b',
+					fillOpacity: 1,
+					strokeColor: '#fff',
+					strokeWeight: 2
+				},
+				title: alert.type || 'Alerta',
+				zIndex: 500
+			});
+
+			const infoWindow = new this.google.maps.InfoWindow({
+				content: `<div style="background:#0c1829;color:#fff;padding:10px 14px;border-radius:8px;font-size:13px;font-weight:600;">
+					<span style="color:#f59e0b;">⚠</span> ${alert.type || 'Alerta'}
+				</div>`
+			});
+
+			let isOpen = false;
+			marker.addListener('click', () => {
+				if (isOpen) {
+					infoWindow.close();
+					isOpen = false;
+				} else {
+					infoWindow.open(this.map, marker);
+					isOpen = true;
+				}
+			});
+			infoWindow.addListener('closeclick', () => {
+				isOpen = false;
+			});
+
+			this._tripAlertMarkers.push(marker);
+		}
+	}
+
+	/** Oculta marcadores de alertas */
+	hideTripAlerts() {
+		for (const marker of this._tripAlertMarkers) {
+			marker.setMap(null);
+		}
+		this._tripAlertMarkers = [];
 	}
 }
 

--- a/src/lib/stores/tripStore.js
+++ b/src/lib/stores/tripStore.js
@@ -1,0 +1,103 @@
+import { writable, derived } from 'svelte/store';
+import { apiService } from '$lib/services/api.js';
+
+export const trips = writable([]);
+export const selectedTripId = writable(null);
+export const loadingTrips = writable(false);
+export const tripError = writable(null);
+
+export const selectedTrip = derived([trips, selectedTripId], ([$trips, $selectedTripId]) => {
+	if (!$selectedTripId) return null;
+	return $trips.find((t) => t.trip_id === $selectedTripId) || null;
+});
+
+function formatDate(date) {
+	return date.toISOString();
+}
+
+function getTodayRange() {
+	const now = new Date();
+	const start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0);
+	const end = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59);
+	return { start, end };
+}
+
+export const tripActions = {
+	async loadTripsForUnit(unitId, options = {}) {
+		if (!unitId) return [];
+
+		loadingTrips.set(true);
+		tripError.set(null);
+
+		try {
+			const { start, end } = options.dateRange || getTodayRange();
+			const params = {
+				start_date: formatDate(start),
+				end_date: formatDate(end),
+				limit: options.limit || 50
+			};
+
+			if (options.cursor) {
+				params.cursor = options.cursor;
+			}
+
+			const response = await apiService.request(
+				`/units/${encodeURIComponent(unitId)}/trips?${new URLSearchParams(params)}`,
+				{ method: 'GET' }
+			);
+
+			const tripList = response?.trips || [];
+			trips.set(tripList);
+			return {
+				trips: tripList,
+				hasMore: response?.has_more || false,
+				cursor: response?.cursor || null,
+				total: response?.total || tripList.length
+			};
+		} catch (error) {
+			console.error('Error cargando trayectos:', error);
+			tripError.set(error.message || 'Error al cargar trayectos');
+			trips.set([]);
+			return { trips: [], hasMore: false, cursor: null, total: 0 };
+		} finally {
+			loadingTrips.set(false);
+		}
+	},
+
+	async loadTripDetail(tripId, options = {}) {
+		if (!tripId) return null;
+
+		try {
+			const params = new URLSearchParams();
+			if (options.includePoints) params.set('include_points', 'true');
+			if (options.includeAlerts) params.set('include_alerts', 'true');
+			if (options.includeEvents) params.set('include_events', 'true');
+
+			const queryString = params.toString();
+			const url = `/trips/${encodeURIComponent(tripId)}${queryString ? `?${queryString}` : ''}`;
+
+			const detail = await apiService.request(url, { method: 'GET' });
+
+			trips.update((list) => list.map((t) => (t.trip_id === tripId ? { ...t, ...detail } : t)));
+
+			return detail;
+		} catch (error) {
+			console.error('Error cargando detalle del trayecto:', error);
+			return null;
+		}
+	},
+
+	selectTrip(tripId) {
+		selectedTripId.set(tripId);
+	},
+
+	clearSelection() {
+		selectedTripId.set(null);
+	},
+
+	clearTrips() {
+		trips.set([]);
+		selectedTripId.set(null);
+		tripError.set(null);
+	}
+};

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -39,6 +39,7 @@
 	import TabAjustes from '$lib/components/TabAjustes.svelte';
 	import ZonasPanel from '$lib/components/ZonasPanel.svelte';
 	import TrackingContextPanel from '$lib/components/TrackingContextPanel.svelte';
+	import TripHistoryPanel from '$lib/components/TripHistoryPanel.svelte';
 	import VehicleListPanel from '$lib/components/VehicleListPanel.svelte';
 
 	let isLoading = true;
@@ -121,6 +122,9 @@
 		'Configuración';
 
 	function onTrackingPanelViewChange(nextView) {
+		if (trackingPanelView === 'trips' && nextView !== 'trips') {
+			mapService.clearTripRoute();
+		}
 		trackingPanelView = nextView;
 	}
 
@@ -508,17 +512,26 @@
 		{#if $activeUnit}
 			<div class="pointer-events-none fixed bottom-24 right-4 z-[100] hidden w-[340px] md:block">
 				<div class="pointer-events-auto overflow-hidden rounded-2xl shadow-2xl">
-					<TrackingContextPanel
-						unit={$activeUnit}
-						units={$vehicles}
-						panelView={trackingPanelView}
-						onPanelViewChange={onTrackingPanelViewChange}
-						onSelectUnit={(u) => {
-							vehicleActions.setActiveUnit(u.id);
-							mapService.centerOnVehicle(u);
-						}}
-						onCenterUnit={centerOnActiveUnit}
-					/>
+					{#if trackingPanelView === 'trips'}
+						<div class="max-h-[70vh] bg-[#0c1829]">
+							<TripHistoryPanel
+								unit={$activeUnit}
+								onBack={() => onTrackingPanelViewChange('unit-info')}
+							/>
+						</div>
+					{:else}
+						<TrackingContextPanel
+							unit={$activeUnit}
+							units={$vehicles}
+							panelView={trackingPanelView}
+							onPanelViewChange={onTrackingPanelViewChange}
+							onSelectUnit={(u) => {
+								vehicleActions.setActiveUnit(u.id);
+								mapService.centerOnVehicle(u);
+							}}
+							onCenterUnit={centerOnActiveUnit}
+						/>
+					{/if}
 				</div>
 			</div>
 		{/if}
@@ -714,18 +727,29 @@
 			class="fixed bottom-[calc(56px+env(safe-area-inset-bottom,0px)+8px)] left-2 right-2 z-[55] sm:hidden"
 			transition:fly={{ y: 20, duration: 200, easing: cubicOut }}
 		>
-			<TrackingContextPanel
-				unit={$activeUnit}
-				units={$vehicles}
-				panelView={trackingPanelView}
-				onPanelViewChange={onTrackingPanelViewChange}
-				onCenterUnit={centerOnActiveUnit}
-				onSelectUnit={(id) => {
-					vehicleActions.setActiveUnit(id);
-					const v = $vehicles.find((u) => u.id === id);
-					if (v) mapService.centerOnVehicle(v);
-				}}
-			/>
+			{#if trackingPanelView === 'trips'}
+				<div
+					class="max-h-[60vh] overflow-hidden rounded-2xl bg-[#0c1829] shadow-[0_-4px_20px_rgba(0,0,0,0.5)]"
+				>
+					<TripHistoryPanel
+						unit={$activeUnit}
+						onBack={() => onTrackingPanelViewChange('unit-info')}
+					/>
+				</div>
+			{:else}
+				<TrackingContextPanel
+					unit={$activeUnit}
+					units={$vehicles}
+					panelView={trackingPanelView}
+					onPanelViewChange={onTrackingPanelViewChange}
+					onCenterUnit={centerOnActiveUnit}
+					onSelectUnit={(id) => {
+						vehicleActions.setActiveUnit(id);
+						const v = $vehicles.find((u) => u.id === id);
+						if (v) mapService.centerOnVehicle(v);
+					}}
+				/>
+			{/if}
 		</div>
 	{/if}
 


### PR DESCRIPTION
## Summary

- Add trip history panel accessible from the contextual tracking panel "Trayectos" button
- Implement trip list view with date selector showing trips for selected unit
- Add trip detail view with statistics cards (Distance, Duration, Alerts, Points)
- Implement animated route playback with play/pause/stop controls
- Add alert markers on map with toggle visibility and tooltips

## Changes

- **New components:**
  - `TripHistoryPanel.svelte` - Trip list with date picker and navigation to detail
  - `TripDetailView.svelte` - Statistics cards and playback controls (matching iOS/Android UI)

- **New store:**
  - `tripStore.js` - Manages trips state, loading, selection, and trip detail fetching

- **Enhanced mapService.js:**
  - `drawTripRoute(points)` - Draws green polyline with start/end markers
  - `startTripPlayback()` / `pauseTripPlayback()` / `stopTripPlayback()` - Animated marker following route
  - `showTripAlerts()` / `hideTripAlerts()` - Yellow alert markers with toggle tooltip
  - `fitBoundsToPoints()` - Fit map to show entire route
  - Limited initial zoom to 12 when centering on vehicles