### PR TITLE
feat: tracking units UI, light theme, and responsive layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Seguimiento units UI: telemetry cards, status filters, and map visibility toggles (`MapVisibleUnitsCard`); dual light/dark panels across tracking and reports unit picker
+
 - Map follow mode: botón "Seguir" en el panel de unidad con autoenfoque (zoom 15) y rastro en vivo con degradado
 
 - Vitest coverage gates (`test:coverage`) with thresholds on `src/lib/**` (90/90/70/90)
@@ -20,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI uploads coverage artifact; `audit` and `e2e` jobs are blocking (no `continue-on-error`)
 
 ### Changed
+
+- Responsive tracking layout: tablet bottom sheet for seguimiento; floating “Unidades visibles” on desktop (lg+) only; hide vehicle InfoWindow on mobile; map initializes from saved theme (early `app.html` theme script)
 
 - `npm run validate` runs `test:coverage` instead of plain `test`
 - npm override for `js-yaml` audit advisory

--- a/src/app.html
+++ b/src/app.html
@@ -7,6 +7,23 @@
 		<meta name="theme-color" data-nexus-dynamic content="#020617" />
 		<meta name="application-name" content="NEXUS" />
 		<meta name="format-detection" content="telephone=no" />
+		<script>
+			(function () {
+				try {
+					var key = 'nexus-theme';
+					var t = localStorage.getItem(key);
+					if (t !== 'light' && t !== 'dark') {
+						t = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+					}
+					document.documentElement.dataset.theme = t;
+					document.documentElement.classList.toggle('dark', t === 'dark');
+					var meta = document.querySelector('meta[name="theme-color"][data-nexus-dynamic]');
+					if (meta) meta.setAttribute('content', t === 'dark' ? '#020617' : '#f8fafc');
+				} catch (e) {
+					/* ignore */
+				}
+			})();
+		</script>
 		%sveltekit.head%
 	</head>
 

--- a/src/lib/components/DrawerConfiguracion.svelte
+++ b/src/lib/components/DrawerConfiguracion.svelte
@@ -6,6 +6,7 @@
 		loadingVehicles,
 		loadingPositions,
 		activeVehicles,
+		mapVisibleUnitIds,
 		vehicleActions
 	} from '$lib/stores/vehicleStore.js';
 	import {
@@ -23,9 +24,12 @@
 	import AdminPanel from './AdminPanel.svelte';
 	import UnitProfileDetails from './Unit/UnitProfileDetails.svelte';
 	import UnitEditPanel from './Unit/UnitEditPanel.svelte';
+	import ColoredVehicleIcon from './Unit/ColoredVehicleIcon.svelte';
 	import { user } from '$lib/stores/auth.js';
 	import { mapService } from '$lib/services/mapService.js';
-	import { getStatusText } from '$lib/utils/vehicleUtils.js';
+	import { getStatusText, colorSlugToHex } from '$lib/utils/vehicleUtils.js';
+	import { isUnitMoving } from '$lib/utils/unitTrackingStatus.js';
+	import { unitIcons } from '$lib/data/unitIcons';
 	import { formatAlarmWhen } from '$lib/utils/alarmFormat.js';
 	import { onMount, createEventDispatcher } from 'svelte';
 	import { get } from 'svelte/store';
@@ -44,9 +48,19 @@
 	// ── Unidades ──────────────────────────────────────────────
 	let vehicleView = 'grid';
 	let vehiclePage = 1;
-	const PAGE_SIZE = 10;
+	let pageSize = 10;
+	const PAGE_SIZE_OPTIONS = [10, 25, 50];
 	let filterStatus = 'all';
 	let filterSearch = '';
+	let showAdvancedFilters = false;
+	/** @type {'all' | 'on' | 'off'} */
+	let filterIgnition = 'all';
+	/** @type {'all' | 'moving' | 'stopped'} */
+	let filterMotion = 'all';
+	/** @type {'all' | 'with' | 'without'} */
+	let filterGps = 'all';
+	/** @type {'name' | 'speed' | 'updated'} */
+	let sortBy = 'name';
 	let actionLoading = false;
 	let vehicleToDelete = null;
 	/** @type {Record<string, unknown> | null} */
@@ -86,23 +100,111 @@
 	}
 
 	// ── Filtros unidades ──────────────────────────────────────
-	$: filteredVehicles = $vehicles.filter((v) => {
-		const matchStatus = filterStatus === 'all' || v.status === filterStatus;
+	$: inactiveCount = $vehicles.filter((v) => v.status === 'inactive').length;
+	$: maintenanceCount = $vehicles.filter((v) => v.status === 'maintenance').length;
+	$: advancedFilterCount =
+		(filterIgnition !== 'all' ? 1 : 0) +
+		(filterMotion !== 'all' ? 1 : 0) +
+		(filterGps !== 'all' ? 1 : 0) +
+		(sortBy !== 'name' ? 1 : 0) +
+		(pageSize !== 10 ? 1 : 0);
+	$: filteredVehicles = (() => {
 		const q = filterSearch.toLowerCase();
-		const matchSearch =
-			!q ||
-			v.name?.toLowerCase().includes(q) ||
-			v.driver?.toLowerCase().includes(q) ||
-			v.location?.toLowerCase().includes(q) ||
-			v.description?.toLowerCase().includes(q);
-		return matchStatus && matchSearch;
-	});
-	$: totalPages = Math.max(1, Math.ceil(filteredVehicles.length / PAGE_SIZE));
-	$: pagedVehicles = filteredVehicles.slice((vehiclePage - 1) * PAGE_SIZE, vehiclePage * PAGE_SIZE);
+		let list = $vehicles.filter((v) => {
+			const matchStatus = filterStatus === 'all' || v.status === filterStatus;
+			const matchSearch =
+				!q ||
+				v.name?.toLowerCase().includes(q) ||
+				v.driver?.toLowerCase().includes(q) ||
+				v.location?.toLowerCase().includes(q) ||
+				v.description?.toLowerCase().includes(q) ||
+				v.brand?.toLowerCase().includes(q) ||
+				v.model?.toLowerCase().includes(q) ||
+				v.plate?.toLowerCase().includes(q);
+			if (!matchStatus || !matchSearch) return false;
+
+			if (filterIgnition === 'on' && String(v.engineStatus ?? '').toUpperCase() !== 'ON') {
+				return false;
+			}
+			if (filterIgnition === 'off' && String(v.engineStatus ?? '').toUpperCase() === 'ON') {
+				return false;
+			}
+			if (filterMotion === 'moving' && !isUnitMoving(v)) return false;
+			if (filterMotion === 'stopped' && isUnitMoving(v)) return false;
+
+			const hasGps =
+				(v.latitude ?? v.lat) != null &&
+				(v.longitude ?? v.lng) != null &&
+				!Number.isNaN(Number(v.latitude ?? v.lat));
+			if (filterGps === 'with' && !hasGps) return false;
+			if (filterGps === 'without' && hasGps) return false;
+
+			return true;
+		});
+
+		list = [...list].sort((a, b) => {
+			if (sortBy === 'speed') {
+				return (Number(b.speed) || 0) - (Number(a.speed) || 0);
+			}
+			if (sortBy === 'updated') {
+				const ta = new Date(a.lastUpdate || 0).getTime() || 0;
+				const tb = new Date(b.lastUpdate || 0).getTime() || 0;
+				return tb - ta;
+			}
+			return String(a.name || '').localeCompare(String(b.name || ''), 'es', {
+				sensitivity: 'base'
+			});
+		});
+		return list;
+	})();
+	$: totalPages = Math.max(1, Math.ceil(filteredVehicles.length / (Number(pageSize) || 10)));
+	$: safePage = Math.min(vehiclePage, totalPages);
+	$: pageSizeN = Number(pageSize) || 10;
+	$: pagedVehicles = filteredVehicles.slice((safePage - 1) * pageSizeN, safePage * pageSizeN);
+	$: pageFrom = filteredVehicles.length === 0 ? 0 : (safePage - 1) * pageSizeN + 1;
+	$: pageTo = Math.min(safePage * pageSizeN, filteredVehicles.length);
+	$: pageNumbers = buildPageNumbers(safePage, totalPages);
+	$: allFilteredOnMap =
+		filteredVehicles.length > 0 &&
+		filteredVehicles.every((v) => $mapVisibleUnitIds.includes(String(v.id)));
 	$: {
 		filterStatus;
 		filterSearch;
+		filterIgnition;
+		filterMotion;
+		filterGps;
+		sortBy;
+		pageSize;
 		vehiclePage = 1;
+	}
+
+	/** @param {number} current @param {number} total */
+	function buildPageNumbers(current, total) {
+		if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
+		/** @type {Array<number | '…'>} */
+		const pages = [1];
+		const start = Math.max(2, current - 1);
+		const end = Math.min(total - 1, current + 1);
+		if (start > 2) pages.push('…');
+		for (let i = start; i <= end; i++) pages.push(i);
+		if (end < total - 1) pages.push('…');
+		pages.push(total);
+		return pages;
+	}
+
+	function clearAdvancedFilters() {
+		filterIgnition = 'all';
+		filterMotion = 'all';
+		filterGps = 'all';
+		sortBy = 'name';
+		pageSize = 10;
+	}
+
+	function toggleSelectAllOnMap() {
+		vehicleActions.setMapVisibilityForIds(
+			filteredVehicles.map((v) => v.id),
+			!allFilteredOnMap
+		);
 	}
 
 	// ── Sidebar sections ──────────────────────────────────────
@@ -244,12 +346,6 @@
 		if (id === 'gestionar_alertas') return $alerts.length;
 		return 0;
 	}
-	const statusColor = (s) =>
-		s === 'active'
-			? 'bg-emerald-500 shadow-[0_0_6px_rgba(34,197,94,.55)]'
-			: s === 'maintenance'
-				? 'bg-amber-500'
-				: 'bg-red-500';
 	const statusPill = (s) =>
 		s === 'active'
 			? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-500/15 dark:text-emerald-300'
@@ -262,12 +358,51 @@
 			: n > 40
 				? 'text-amber-600 dark:text-amber-200'
 				: 'text-emerald-600 dark:text-emerald-300';
-	const battColor = (n) =>
-		n < 25
-			? 'text-red-600 dark:text-red-300'
-			: n < 50
-				? 'text-amber-600 dark:text-amber-200'
-				: 'text-emerald-600 dark:text-emerald-300';
+
+	function unitIconSrc(v) {
+		const iconType = v?.icon_type || v?.iconType || 'vehicle-car-sedan';
+		return unitIcons[iconType] || unitIcons['vehicle-car-sedan'];
+	}
+	function unitColorHex(v) {
+		return colorSlugToHex(v?.color) || v?.profile_color_hex || '#94a3b8';
+	}
+	function unitTypeLabel(v) {
+		const fromProfile = [v?.brand, v?.model].filter(Boolean).join(' ');
+		if (fromProfile) return fromProfile;
+		const t = v?.icon_type || v?.iconType || '';
+		const labels = {
+			'vehicle-car-sedan': 'Auto sedan',
+			'vehicle-car-truck': 'Camioneta',
+			'vehicle-backhoe-loader': 'Retroexcavadora',
+			'vehicle-motorbike-sport': 'Motocicleta',
+			'vehicle-trailer-dryvan': 'Remolque'
+		};
+		return labels[t] || v?.location || 'Unidad';
+	}
+	function ignitionOn(v) {
+		return String(v?.engineStatus ?? '').toUpperCase() === 'ON';
+	}
+	function formatSpeed(v) {
+		const spd = Number(v?.speed);
+		if (v?.speed == null || Number.isNaN(spd)) return '—';
+		return `${spd.toFixed(2)} km/h`;
+	}
+	function formatVoltage(val) {
+		const n = Number(val);
+		if (val == null || Number.isNaN(n)) return '—';
+		return n.toFixed(1);
+	}
+	function formatSignal(v) {
+		const n = Number(v?.rxLvl);
+		if (v?.rxLvl == null || Number.isNaN(n)) return '—';
+		return `${n} dBm`;
+	}
+	function statusLabelEs(status) {
+		if (status === 'active') return 'Activa';
+		if (status === 'inactive') return 'Inactiva';
+		if (status === 'maintenance') return 'Mantenimiento';
+		return getStatusText(status);
+	}
 </script>
 
 {#if $alertWizard}
@@ -489,63 +624,10 @@
 					</div>
 				{:else}
 					<div
-						class="shrink-0 border-b border-slate-200 bg-slate-50 px-4 py-3 space-y-2.5 dark:border-white/[0.06] dark:bg-[#080d1a]"
+						class="shrink-0 space-y-2.5 border-b border-slate-200 bg-slate-50 px-4 py-3 dark:border-white/[0.06] dark:bg-[#080d1a]"
 					>
 						<div class="flex items-center gap-2">
-							<Icon
-								icon="mdi:car-side"
-								width={14}
-								class="shrink-0 text-slate-500 dark:text-white/35"
-								aria-hidden="true"
-							/>
-							<span class="text-[14px] font-bold text-slate-900 dark:text-white">Unidades</span>
-							<div class="flex items-center gap-1 ml-auto">
-								<div
-									class="flex overflow-hidden rounded-lg border border-slate-200 dark:border-white/[0.08]"
-								>
-									<button
-										type="button"
-										class="flex h-7 w-7 items-center justify-center transition-colors {vehicleView ===
-										'grid'
-											? 'bg-blue-100 text-blue-700 dark:bg-blue-600/20 dark:text-blue-300'
-											: 'text-slate-500 hover:text-slate-800 dark:text-white/35 dark:hover:text-white/60'}"
-										on:click={() => (vehicleView = 'grid')}
-										title="Vista tarjeta"
-										aria-pressed={vehicleView === 'grid'}
-									>
-										<Icon icon="mdi:view-grid-outline" width={15} aria-hidden="true" />
-									</button>
-									<button
-										type="button"
-										class="flex h-7 w-7 items-center justify-center transition-colors {vehicleView ===
-										'list'
-											? 'bg-blue-100 text-blue-700 dark:bg-blue-600/20 dark:text-blue-300'
-											: 'text-slate-500 hover:text-slate-800 dark:text-white/35 dark:hover:text-white/60'}"
-										on:click={() => (vehicleView = 'list')}
-										title="Vista lista"
-										aria-pressed={vehicleView === 'list'}
-									>
-										<Icon icon="mdi:view-list-outline" width={15} aria-hidden="true" />
-									</button>
-								</div>
-								<button
-									type="button"
-									class="flex h-7 items-center gap-1 rounded-lg border border-blue-500/25 bg-blue-50 px-2 text-[11px] font-semibold text-blue-700 transition-colors hover:bg-blue-100 disabled:opacity-40 dark:bg-blue-600/12 dark:text-blue-300 dark:hover:bg-blue-600/20"
-									on:click={refreshPositions}
-									disabled={$loadingPositions}
-								>
-									<Icon
-										icon="mdi:refresh"
-										width={13}
-										class={$loadingPositions ? 'animate-spin' : ''}
-										aria-hidden="true"
-									/>
-									{$loadingPositions ? 'Actualizando…' : 'Actualizar'}
-								</button>
-							</div>
-						</div>
-						<div class="flex gap-2">
-							<div class="relative flex-1">
+							<div class="relative min-w-0 flex-1">
 								<Icon
 									icon="mdi:magnify"
 									width={13}
@@ -555,44 +637,213 @@
 								<input
 									type="search"
 									placeholder="Buscar unidad, conductor…"
-									class="h-7 w-full rounded-lg border border-slate-200 bg-white pl-7 pr-3 text-[11px] text-slate-900 outline-none placeholder:text-slate-400 focus:border-blue-500/50 dark:border-white/[0.1] dark:bg-white/[0.05] dark:text-white dark:placeholder:text-white/22"
+									class="h-8 w-full rounded-lg border border-slate-200 bg-white pl-7 pr-10 text-[12px] text-slate-900 outline-none placeholder:text-slate-400 focus:border-emerald-500/50 dark:border-white/[0.1] dark:bg-white/[0.05] dark:text-white dark:placeholder:text-white/22"
 									bind:value={filterSearch}
 								/>
+								<button
+									type="button"
+									class="absolute right-1 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-md transition-colors {showAdvancedFilters ||
+									advancedFilterCount > 0
+										? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300'
+										: 'text-slate-400 hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-white/10 dark:hover:text-white/70'}"
+									on:click={() => (showAdvancedFilters = !showAdvancedFilters)}
+									aria-expanded={showAdvancedFilters}
+									aria-label="Filtros avanzados"
+									title="Filtros avanzados"
+								>
+									<Icon icon="mdi:filter-variant" width={15} aria-hidden="true" />
+									{#if advancedFilterCount > 0}
+										<span
+											class="absolute -right-0.5 -top-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-emerald-600 px-0.5 text-[8px] font-bold text-white"
+											>{advancedFilterCount}</span
+										>
+									{/if}
+								</button>
 							</div>
-							<select
-								bind:value={filterStatus}
-								class="h-7 cursor-pointer rounded-lg border border-slate-200 bg-white px-2 text-[11px] text-slate-900 outline-none focus:border-blue-500/50 dark:border-white/[0.1] dark:bg-white/[0.05] dark:text-white"
+							<div
+								class="flex shrink-0 overflow-hidden rounded-lg border border-slate-200 dark:border-white/[0.08]"
 							>
-								<option value="all">Todos</option>
-								<option value="active">Activos</option>
-								<option value="maintenance">Mantenimiento</option>
-								<option value="inactive">Inactivos</option>
-							</select>
+								<button
+									type="button"
+									class="flex h-8 w-8 items-center justify-center transition-colors {vehicleView ===
+									'grid'
+										? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-600/20 dark:text-emerald-300'
+										: 'text-slate-500 hover:text-slate-800 dark:text-white/35 dark:hover:text-white/60'}"
+									on:click={() => (vehicleView = 'grid')}
+									title="Vista tarjeta"
+									aria-pressed={vehicleView === 'grid'}
+								>
+									<Icon icon="mdi:view-grid-outline" width={15} aria-hidden="true" />
+								</button>
+								<button
+									type="button"
+									class="flex h-8 w-8 items-center justify-center transition-colors {vehicleView ===
+									'list'
+										? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-600/20 dark:text-emerald-300'
+										: 'text-slate-500 hover:text-slate-800 dark:text-white/35 dark:hover:text-white/60'}"
+									on:click={() => (vehicleView = 'list')}
+									title="Vista lista"
+									aria-pressed={vehicleView === 'list'}
+								>
+									<Icon icon="mdi:view-list-outline" width={15} aria-hidden="true" />
+								</button>
+							</div>
+							<button
+								type="button"
+								class="flex h-8 shrink-0 items-center gap-1 rounded-lg border border-emerald-500/25 bg-emerald-50 px-2 text-[11px] font-semibold text-emerald-700 transition-colors hover:bg-emerald-100 disabled:opacity-40 dark:bg-emerald-600/12 dark:text-emerald-300 dark:hover:bg-emerald-600/20"
+								on:click={refreshPositions}
+								disabled={$loadingPositions}
+							>
+								<Icon
+									icon="mdi:refresh"
+									width={13}
+									class={$loadingPositions ? 'animate-spin' : ''}
+									aria-hidden="true"
+								/>
+								{$loadingPositions ? '…' : 'Actualizar'}
+							</button>
 						</div>
-						<div class="flex items-center gap-2 flex-wrap">
-							<span
-								class="flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-semibold text-emerald-800 dark:bg-emerald-500/10 dark:text-emerald-300"
+						<div
+							class="flex flex-wrap items-center gap-2"
+							role="group"
+							aria-label="Filtrar por estado"
+						>
+							<button
+								type="button"
+								class="flex items-center gap-1 rounded-full border px-2.5 py-1 text-[10px] font-semibold transition-colors {filterStatus ===
+								'active'
+									? 'border-emerald-500/40 bg-emerald-500/15 text-emerald-800 dark:text-emerald-200'
+									: 'border-transparent bg-emerald-100 text-emerald-800 hover:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-300'}"
+								on:click={() => (filterStatus = filterStatus === 'active' ? 'all' : 'active')}
+								aria-pressed={filterStatus === 'active'}
 							>
-								<span class="h-1 w-1 rounded-full bg-emerald-500"></span>{$activeVehicles.length} activos
-							</span>
-							<span
-								class="flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-800 dark:bg-amber-500/10 dark:text-amber-300"
+								<span class="h-1.5 w-1.5 rounded-full bg-emerald-500"
+								></span>{$activeVehicles.length} Activas
+							</button>
+							<button
+								type="button"
+								class="flex items-center gap-1 rounded-full border px-2.5 py-1 text-[10px] font-semibold transition-colors {filterStatus ===
+								'maintenance'
+									? 'border-amber-500/40 bg-amber-500/15 text-amber-900 dark:text-amber-200'
+									: 'border-transparent bg-amber-100 text-amber-800 hover:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300'}"
+								on:click={() =>
+									(filterStatus = filterStatus === 'maintenance' ? 'all' : 'maintenance')}
+								aria-pressed={filterStatus === 'maintenance'}
 							>
-								<span class="h-1 w-1 rounded-full bg-amber-500"></span>{$vehicles.filter(
-									(v) => v.status === 'maintenance'
-								).length} mantenimiento
-							</span>
-							<span
-								class="flex items-center gap-1 rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-semibold text-red-800 dark:bg-red-500/10 dark:text-red-300"
+								<span class="h-1.5 w-1.5 rounded-full bg-amber-500"></span>{maintenanceCount} Mantenimiento
+							</button>
+							<button
+								type="button"
+								class="flex items-center gap-1 rounded-full border px-2.5 py-1 text-[10px] font-semibold transition-colors {filterStatus ===
+								'inactive'
+									? 'border-red-500/40 bg-red-500/15 text-red-800 dark:text-red-200'
+									: 'border-transparent bg-red-100 text-red-800 hover:border-red-500/30 dark:bg-red-500/10 dark:text-red-300'}"
+								on:click={() => (filterStatus = filterStatus === 'inactive' ? 'all' : 'inactive')}
+								aria-pressed={filterStatus === 'inactive'}
 							>
-								<span class="h-1 w-1 rounded-full bg-red-500"></span>{$vehicles.filter(
-									(v) => v.status === 'inactive'
-								).length} inactivos
-							</span>
-							<span class="ml-auto text-[10px] text-slate-500 dark:text-white/22"
-								>{filteredVehicles.length} resultados</span
-							>
+								<span class="h-1.5 w-1.5 rounded-full bg-red-500"></span>{inactiveCount} Inactivas
+							</button>
 						</div>
+						{#if showAdvancedFilters}
+							<div
+								class="space-y-2.5 rounded-xl border border-emerald-500/20 bg-white p-3 dark:border-emerald-400/20 dark:bg-white/[0.04]"
+							>
+								<div class="flex items-center justify-between gap-2">
+									<p
+										class="m-0 text-[11px] font-bold uppercase tracking-wide text-slate-500 dark:text-white/45"
+									>
+										Filtros avanzados
+									</p>
+									<button
+										type="button"
+										class="text-[10px] font-semibold text-emerald-700 hover:underline dark:text-emerald-300"
+										on:click={clearAdvancedFilters}
+										disabled={advancedFilterCount === 0}
+									>
+										Limpiar
+									</button>
+								</div>
+								<div class="grid grid-cols-2 gap-2">
+									<label
+										class="flex flex-col gap-1 text-[10px] font-medium text-slate-500 dark:text-white/40"
+									>
+										Ignición
+										<select
+											bind:value={filterIgnition}
+											class="h-7 rounded-lg border border-slate-200 bg-slate-50 px-2 text-[11px] text-slate-900 dark:border-white/10 dark:bg-white/[0.06] dark:text-white"
+										>
+											<option value="all">Todas</option>
+											<option value="on">Encendida</option>
+											<option value="off">Apagada</option>
+										</select>
+									</label>
+									<label
+										class="flex flex-col gap-1 text-[10px] font-medium text-slate-500 dark:text-white/40"
+									>
+										Movimiento
+										<select
+											bind:value={filterMotion}
+											class="h-7 rounded-lg border border-slate-200 bg-slate-50 px-2 text-[11px] text-slate-900 dark:border-white/10 dark:bg-white/[0.06] dark:text-white"
+										>
+											<option value="all">Todas</option>
+											<option value="moving">En movimiento</option>
+											<option value="stopped">Detenidas</option>
+										</select>
+									</label>
+									<label
+										class="flex flex-col gap-1 text-[10px] font-medium text-slate-500 dark:text-white/40"
+									>
+										GPS
+										<select
+											bind:value={filterGps}
+											class="h-7 rounded-lg border border-slate-200 bg-slate-50 px-2 text-[11px] text-slate-900 dark:border-white/10 dark:bg-white/[0.06] dark:text-white"
+										>
+											<option value="all">Todas</option>
+											<option value="with">Con posición</option>
+											<option value="without">Sin posición</option>
+										</select>
+									</label>
+									<label
+										class="flex flex-col gap-1 text-[10px] font-medium text-slate-500 dark:text-white/40"
+									>
+										Ordenar
+										<select
+											bind:value={sortBy}
+											class="h-7 rounded-lg border border-slate-200 bg-slate-50 px-2 text-[11px] text-slate-900 dark:border-white/10 dark:bg-white/[0.06] dark:text-white"
+										>
+											<option value="name">Nombre</option>
+											<option value="speed">Velocidad</option>
+											<option value="updated">Última act.</option>
+										</select>
+									</label>
+								</div>
+								<label
+									class="flex flex-col gap-1 text-[10px] font-medium text-slate-500 dark:text-white/40"
+								>
+									Por página
+									<select
+										bind:value={pageSize}
+										class="h-7 rounded-lg border border-slate-200 bg-slate-50 px-2 text-[11px] text-slate-900 dark:border-white/10 dark:bg-white/[0.06] dark:text-white"
+									>
+										{#each PAGE_SIZE_OPTIONS as n (n)}
+											<option value={n}>{n} unidades</option>
+										{/each}
+									</select>
+								</label>
+							</div>
+						{/if}
+						<label
+							class="flex cursor-pointer items-center gap-2 text-[11px] font-medium text-slate-600 dark:text-white/55"
+						>
+							<input
+								type="checkbox"
+								class="size-3.5 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500 dark:border-slate-500"
+								checked={allFilteredOnMap}
+								disabled={filteredVehicles.length === 0}
+								on:change={toggleSelectAllOnMap}
+							/>
+							Seleccionar todas ({filteredVehicles.length}) en mapa
+						</label>
 					</div>
 					<div class="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-3">
 						{#if $loadingVehicles}
@@ -600,7 +851,7 @@
 								class="flex items-center justify-center gap-3 py-12 text-slate-500 dark:text-white/38"
 							>
 								<span
-									class="h-5 w-5 animate-spin rounded-full border-2 border-blue-600/20 border-t-blue-500"
+									class="h-5 w-5 animate-spin rounded-full border-2 border-emerald-600/20 border-t-emerald-500"
 								></span>
 								<span class="text-[12px]">Cargando unidades…</span>
 							</div>
@@ -615,125 +866,191 @@
 								<span class="text-[12px]">Sin resultados</span>
 							</div>
 						{:else if vehicleView === 'grid'}
-							<ul
-								class="grid grid-cols-[repeat(auto-fill,minmax(190px,1fr))] gap-2.5 list-none p-0 m-0"
-							>
+							<ul class="m-0 flex list-none flex-col gap-2.5 p-0">
 								{#each pagedVehicles as v (v.id)}
 									<li
-										class="flex flex-col gap-2 rounded-xl border p-3 transition-colors hover:bg-slate-50 dark:hover:bg-white/[0.05]
-									{v.status === 'active'
-											? 'border-emerald-300 bg-emerald-50 dark:border-emerald-500/20 dark:bg-emerald-500/[0.03]'
-											: v.status === 'maintenance'
-												? 'border-amber-300 bg-amber-50 dark:border-amber-500/20 dark:bg-amber-500/[0.03]'
-												: 'border-slate-200 bg-white dark:border-white/[0.07] dark:bg-white/[0.02]'}"
+										class="rounded-xl border border-slate-200 bg-white p-3 shadow-sm transition-colors dark:border-white/[0.08] dark:bg-white/[0.03]"
 									>
-										<div class="flex items-center gap-1.5">
-											<span
-												class="h-2 w-2 shrink-0 rounded-full {statusColor(v.status)}"
-												aria-hidden="true"
-											></span>
-											<span
-												class="min-w-0 flex-1 truncate text-[12px] font-bold text-slate-900 dark:text-white"
-												>{v.name}</span
-											>
-											<span
-												class="shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-bold {statusPill(
-													v.status
-												)}">{getStatusText(v.status)}</span
-											>
-										</div>
-										<div
-											class="flex flex-col gap-0.5 text-[11px] text-slate-600 dark:text-white/40"
-										>
-											<span class="flex items-center gap-1"
-												><Icon icon="mdi:account" width={11} aria-hidden="true" />{v.driver ||
-													'Sin conductor'}</span
-											>
-											<span class="flex items-center gap-1 truncate"
-												><Icon icon="mdi:map-marker" width={11} aria-hidden="true" />{v.location ||
-													'—'}</span
-											>
-										</div>
-										{#if v.speed !== undefined}
-											<div
-												class="flex gap-3 border-t border-slate-100 pt-1.5 dark:border-white/[0.05]"
-											>
-												<div class="flex items-baseline gap-0.5">
-													<span class="text-[14px] font-bold {speedColor(v.speed)}">{v.speed}</span>
-													<span class="text-[9px] text-slate-500 dark:text-white/25">km/h</span>
-												</div>
-												<div class="flex items-baseline gap-0.5">
-													<span class="text-[14px] font-bold {battColor(v.battery || 0)}"
-														>{v.battery || 0}</span
+										<div class="flex items-start gap-2.5">
+											<input
+												type="checkbox"
+												class="mt-1 size-3.5 shrink-0 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500 dark:border-slate-500"
+												checked={$mapVisibleUnitIds.includes(String(v.id))}
+												on:change={() => vehicleActions.toggleMapVisibility(v.id)}
+												aria-label="Mostrar {v.name} en el mapa"
+											/>
+											<div class="flex h-9 w-9 shrink-0 items-center justify-center">
+												<ColoredVehicleIcon
+													src={unitIconSrc(v)}
+													colorHex={unitColorHex(v)}
+													sizeClass="h-8 w-8"
+													alt=""
+												/>
+											</div>
+											<div class="min-w-0 flex-1">
+												<div class="flex items-start justify-between gap-2">
+													<p
+														class="m-0 truncate text-[13px] font-bold text-slate-900 dark:text-white"
 													>
-													<span class="text-[9px] text-slate-500 dark:text-white/25">%bat</span>
+														{v.name}
+													</p>
+													<span
+														class="inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-semibold {statusPill(
+															v.status
+														)}">{statusLabelEs(v.status)}</span
+													>
+												</div>
+												<div
+													class="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-slate-500 dark:text-white/45"
+												>
+													<span class="inline-flex items-center gap-1">
+														<Icon icon="mdi:account-outline" width={12} aria-hidden="true" />
+														{v.driver || 'Sin conductor'}
+													</span>
+													<span class="inline-flex items-center gap-1">
+														<Icon icon="mdi:map-marker-outline" width={12} aria-hidden="true" />
+														{unitTypeLabel(v)}
+													</span>
+												</div>
+												<div
+													class="mt-2 grid grid-cols-3 gap-2 border-t border-slate-100 pt-2 dark:border-white/[0.06]"
+												>
+													<div>
+														<p
+															class="m-0 text-[9px] font-medium uppercase tracking-wide text-slate-400 dark:text-white/30"
+														>
+															Ignición
+														</p>
+														<p
+															class="m-0 mt-0.5 inline-flex items-center gap-1 text-[11px] font-semibold text-slate-800 dark:text-white/85"
+														>
+															<span
+																class="h-1.5 w-1.5 rounded-full {ignitionOn(v)
+																	? 'bg-emerald-500'
+																	: 'bg-slate-400'}"
+																aria-hidden="true"
+															></span>
+															{ignitionOn(v) ? 'Encendida' : 'Apagada'}
+														</p>
+													</div>
+													<div>
+														<p
+															class="m-0 text-[9px] font-medium uppercase tracking-wide text-slate-400 dark:text-white/30"
+														>
+															Velocidad
+														</p>
+														<p
+															class="m-0 mt-0.5 text-[12px] font-bold {speedColor(
+																Number(v.speed) || 0
+															)}"
+														>
+															{formatSpeed(v)}
+														</p>
+													</div>
+													<div>
+														<p
+															class="m-0 text-[9px] font-medium uppercase tracking-wide text-slate-400 dark:text-white/30"
+														>
+															Actualización
+														</p>
+														<p
+															class="m-0 mt-0.5 truncate text-[11px] font-medium text-slate-700 dark:text-white/70"
+														>
+															{v.lastUpdateFormatted || '—'}
+														</p>
+													</div>
+												</div>
+												<div
+													class="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-slate-500 dark:text-white/40"
+												>
+													<span>
+														<span class="font-semibold text-slate-700 dark:text-white/80"
+															>{formatVoltage(v.mainBatteryVoltage)}</span
+														>
+														Vext
+													</span>
+													<span>
+														<span class="font-semibold text-slate-700 dark:text-white/80"
+															>{formatVoltage(v.backupBatteryVoltage)}</span
+														>
+														Vint
+													</span>
+													<span class="inline-flex items-center gap-1">
+														<Icon icon="mdi:signal" width={12} aria-hidden="true" />
+														<span class="font-semibold text-slate-700 dark:text-white/80"
+															>{formatSignal(v)}</span
+														>
+														Señal
+													</span>
+												</div>
+												<div class="mt-2.5 flex flex-wrap gap-1.5">
+													<button
+														type="button"
+														class="flex items-center gap-1 rounded-lg border border-slate-200 bg-white px-2 py-1 text-[10px] font-semibold text-slate-700 transition-colors hover:bg-slate-100 dark:border-white/[0.1] dark:bg-white/[0.04] dark:text-white/70 dark:hover:bg-white/[0.1]"
+														on:click={() => fetchVehicleDetail(v.id)}
+														disabled={actionLoading}
+													>
+														<Icon
+															icon="mdi:database-search-outline"
+															width={11}
+															aria-hidden="true"
+														/>Obtener
+													</button>
+													<button
+														type="button"
+														class="flex items-center gap-1 rounded-lg border border-emerald-300 bg-emerald-50 px-2 py-1 text-[10px] font-semibold text-emerald-700 transition-colors hover:bg-emerald-100 dark:border-emerald-500/25 dark:bg-emerald-600/12 dark:text-emerald-300 dark:hover:bg-emerald-600/20"
+														on:click={() => openEditVehicle(v)}
+														disabled={actionLoading}
+													>
+														<Icon icon="mdi:pencil-outline" width={11} aria-hidden="true" />Editar
+													</button>
+													<button
+														type="button"
+														class="flex items-center gap-1 rounded-lg border border-red-300 bg-red-50 px-2 py-1 text-[10px] font-semibold text-red-700 transition-colors hover:bg-red-100 dark:border-red-500/25 dark:bg-red-600/12 dark:text-red-300 dark:hover:bg-red-600/20"
+														on:click={() => requestDeleteVehicle(v)}
+														disabled={actionLoading}
+													>
+														<Icon
+															icon="mdi:trash-can-outline"
+															width={11}
+															aria-hidden="true"
+														/>Eliminar
+													</button>
 												</div>
 											</div>
-										{/if}
-										{#if v.lastUpdateFormatted}<div
-												class="text-[9px] text-slate-500 dark:text-white/22"
-											>
-												{v.lastUpdateFormatted}
-											</div>{/if}
-										<div
-											class="mt-1 flex flex-wrap gap-1.5 border-t border-slate-100 pt-1.5 dark:border-white/[0.05]"
-										>
 											<button
 												type="button"
-												class="flex items-center gap-1 rounded-lg border border-slate-200 bg-white px-2 py-1 text-[10px] font-semibold text-slate-700 transition-colors hover:bg-slate-100 dark:border-white/[0.1] dark:bg-white/[0.04] dark:text-white/70 dark:hover:bg-white/[0.1]"
-												on:click={() => fetchVehicleDetail(v.id)}
-												disabled={actionLoading}
+												class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-emerald-600 text-white shadow-sm transition-colors hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-40"
+												on:click={() => centerOnVehicle(v)}
+												disabled={!(v.latitude || v.lat) || !(v.longitude || v.lng)}
+												aria-label="Centrar el mapa en {v.name}"
+												title="Centrar en mapa"
 											>
-												<Icon
-													icon="mdi:database-search-outline"
-													width={11}
-													aria-hidden="true"
-												/>Obtener
-											</button>
-											<button
-												type="button"
-												class="flex items-center gap-1 rounded-lg border border-emerald-300 bg-emerald-50 px-2 py-1 text-[10px] font-semibold text-emerald-700 transition-colors hover:bg-emerald-100 dark:border-emerald-500/25 dark:bg-emerald-600/12 dark:text-emerald-300 dark:hover:bg-emerald-600/20"
-												on:click={() => openEditVehicle(v)}
-												disabled={actionLoading}
-											>
-												<Icon icon="mdi:pencil-outline" width={11} aria-hidden="true" />Editar
-											</button>
-											<button
-												type="button"
-												class="flex items-center gap-1 rounded-lg border border-red-300 bg-red-50 px-2 py-1 text-[10px] font-semibold text-red-700 transition-colors hover:bg-red-100 dark:border-red-500/25 dark:bg-red-600/12 dark:text-red-300 dark:hover:bg-red-600/20"
-												on:click={() => requestDeleteVehicle(v)}
-												disabled={actionLoading}
-											>
-												<Icon icon="mdi:trash-can-outline" width={11} aria-hidden="true" />Eliminar
+												<Icon icon="mdi:crosshairs-gps" width={16} aria-hidden="true" />
 											</button>
 										</div>
-										{#if v.latitude && v.longitude}
-											<button
-												type="button"
-												class="flex w-full items-center justify-center gap-1 rounded-lg border border-blue-200 bg-blue-50 py-1 text-[10px] font-semibold text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-500/20 dark:bg-blue-600/10 dark:text-blue-300 dark:hover:bg-blue-600/18"
-												on:click={() => centerOnVehicle(v)}
-											>
-												<Icon icon="mdi:crosshairs-gps" width={11} aria-hidden="true" />Localizar
-											</button>
-										{/if}
 									</li>
 								{/each}
 							</ul>
 						{:else}
-							<ul class="flex flex-col gap-1 list-none p-0 m-0">
+							<ul class="m-0 flex list-none flex-col gap-1.5 p-0">
 								{#each pagedVehicles as v (v.id)}
 									<li
-										class="flex items-center gap-2.5 rounded-xl border px-3 py-2 transition-colors hover:bg-slate-50 dark:hover:bg-white/[0.05]
-									{v.status === 'active'
-											? 'border-emerald-300 dark:border-emerald-500/18'
-											: v.status === 'maintenance'
-												? 'border-amber-300 dark:border-amber-500/18'
-												: 'border-slate-200 dark:border-white/[0.06]'}"
+										class="flex items-center gap-2.5 rounded-xl border border-slate-200 bg-white px-3 py-2.5 transition-colors hover:bg-slate-50 dark:border-white/[0.08] dark:bg-white/[0.03] dark:hover:bg-white/[0.05]"
 									>
-										<span
-											class="h-2 w-2 shrink-0 rounded-full {statusColor(v.status)}"
-											aria-hidden="true"
-										></span>
+										<input
+											type="checkbox"
+											class="size-3.5 shrink-0 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500 dark:border-slate-500"
+											checked={$mapVisibleUnitIds.includes(String(v.id))}
+											on:change={() => vehicleActions.toggleMapVisibility(v.id)}
+											aria-label="Mostrar {v.name} en el mapa"
+										/>
+										<ColoredVehicleIcon
+											src={unitIconSrc(v)}
+											colorHex={unitColorHex(v)}
+											sizeClass="h-7 w-7"
+											alt=""
+										/>
 										<div class="min-w-0 flex-1">
 											<div class="flex items-center gap-2">
 												<span
@@ -743,90 +1060,114 @@
 												<span
 													class="shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-bold {statusPill(
 														v.status
-													)}">{getStatusText(v.status)}</span
+													)}">{statusLabelEs(v.status)}</span
 												>
 											</div>
-											<div class="mt-0.5 flex gap-2 text-[10px] text-slate-600 dark:text-white/38">
-												<span class="flex items-center gap-0.5"
-													><Icon icon="mdi:account" width={10} aria-hidden="true" />{v.driver ||
-														'—'}</span
-												>
-												{#if v.speed !== undefined}
-													<span class={speedColor(v.speed)}>{v.speed} km/h</span>
-													<span class={battColor(v.battery || 0)}>{v.battery || 0}%</span>
+											<div
+												class="mt-0.5 flex flex-wrap gap-2 text-[10px] text-slate-600 dark:text-white/38"
+											>
+												<span class="inline-flex items-center gap-0.5">
+													<span
+														class="h-1.5 w-1.5 rounded-full {ignitionOn(v)
+															? 'bg-emerald-500'
+															: 'bg-slate-400'}"
+													></span>
+													{ignitionOn(v) ? 'Encendida' : 'Apagada'}
+												</span>
+												<span class={speedColor(Number(v.speed) || 0)}>{formatSpeed(v)}</span>
+												<span>{formatVoltage(v.mainBatteryVoltage)} Vext</span>
+												{#if v.lastUpdateFormatted}
+													<span class="truncate">{v.lastUpdateFormatted}</span>
 												{/if}
 											</div>
 										</div>
-										{#if v.latitude && v.longitude}
-											<button
-												type="button"
-												class="shrink-0 flex h-7 w-7 items-center justify-center rounded-lg border border-blue-200 bg-blue-50 text-blue-700 hover:bg-blue-100 dark:border-blue-500/20 dark:bg-blue-600/10 dark:text-blue-300 dark:hover:bg-blue-600/20"
-												on:click={() => centerOnVehicle(v)}
-											>
-												<Icon icon="mdi:crosshairs-gps" width={13} aria-hidden="true" />
-											</button>
-										{/if}
-										<div class="ml-1 flex shrink-0 items-center gap-1">
-											<button
-												type="button"
-												class="flex h-7 w-7 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 hover:bg-slate-100 dark:border-white/[0.1] dark:bg-white/[0.04] dark:text-white/70 dark:hover:bg-white/[0.1]"
-												on:click={() => fetchVehicleDetail(v.id)}
-												title="Obtener detalle"
-												disabled={actionLoading}
-											>
-												<Icon icon="mdi:database-search-outline" width={13} aria-hidden="true" />
-											</button>
-											<button
-												type="button"
-												class="flex h-7 w-7 items-center justify-center rounded-lg border border-emerald-300 bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:border-emerald-500/25 dark:bg-emerald-600/12 dark:text-emerald-300 dark:hover:bg-emerald-600/20"
-												on:click={() => openEditVehicle(v)}
-												title="Editar"
-												disabled={actionLoading}
-											>
-												<Icon icon="mdi:pencil-outline" width={13} aria-hidden="true" />
-											</button>
-											<button
-												type="button"
-												class="flex h-7 w-7 items-center justify-center rounded-lg border border-red-300 bg-red-50 text-red-700 hover:bg-red-100 dark:border-red-500/25 dark:bg-red-600/12 dark:text-red-300 dark:hover:bg-red-600/20"
-												on:click={() => requestDeleteVehicle(v)}
-												title="Eliminar"
-												disabled={actionLoading}
-											>
-												<Icon icon="mdi:trash-can-outline" width={13} aria-hidden="true" />
-											</button>
-										</div>
+										<button
+											type="button"
+											class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-emerald-600 text-white hover:bg-emerald-700 disabled:opacity-40"
+											on:click={() => centerOnVehicle(v)}
+											disabled={!(v.latitude || v.lat) || !(v.longitude || v.lng)}
+											aria-label="Centrar mapa en {v.name}"
+										>
+											<Icon icon="mdi:crosshairs-gps" width={13} aria-hidden="true" />
+										</button>
+										<button
+											type="button"
+											class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 hover:bg-slate-100 dark:border-white/[0.1] dark:bg-white/[0.04] dark:text-white/70 dark:hover:bg-white/[0.1]"
+											on:click={() => fetchVehicleDetail(v.id)}
+											title="Obtener detalle"
+											disabled={actionLoading}
+										>
+											<Icon icon="mdi:database-search-outline" width={13} aria-hidden="true" />
+										</button>
+										<button
+											type="button"
+											class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-emerald-300 bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:border-emerald-500/25 dark:bg-emerald-600/12 dark:text-emerald-300 dark:hover:bg-emerald-600/20"
+											on:click={() => openEditVehicle(v)}
+											title="Editar"
+											disabled={actionLoading}
+										>
+											<Icon icon="mdi:pencil-outline" width={13} aria-hidden="true" />
+										</button>
+										<button
+											type="button"
+											class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-red-300 bg-red-50 text-red-700 hover:bg-red-100 dark:border-red-500/25 dark:bg-red-600/12 dark:text-red-300 dark:hover:bg-red-600/20"
+											on:click={() => requestDeleteVehicle(v)}
+											title="Eliminar"
+											disabled={actionLoading}
+										>
+											<Icon icon="mdi:trash-can-outline" width={13} aria-hidden="true" />
+										</button>
 									</li>
 								{/each}
 							</ul>
 						{/if}
 					</div>
 
-					{#if totalPages > 1}
-						<div
-							class="flex shrink-0 items-center justify-between border-t border-slate-200 px-4 py-2.5 dark:border-white/[0.06]"
-						>
+					<div
+						class="flex shrink-0 flex-wrap items-center justify-between gap-2 border-t border-slate-200 px-4 py-2.5 dark:border-white/[0.06]"
+					>
+						<span class="text-[11px] text-slate-500 dark:text-white/35">
+							Mostrando {pageFrom} a {pageTo} de {filteredVehicles.length} unidades
+						</span>
+						<div class="flex items-center gap-1">
 							<button
 								type="button"
-								class="flex h-7 items-center gap-1 rounded-lg border border-slate-200 bg-white px-2.5 text-[11px] font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-30 dark:border-white/[0.09] dark:bg-white/[0.04] dark:text-white/55 dark:hover:bg-white/[0.08]"
-								on:click={() => (vehiclePage = Math.max(1, vehiclePage - 1))}
-								disabled={vehiclePage === 1}
+								class="flex h-7 w-7 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 hover:bg-slate-50 disabled:opacity-30 dark:border-white/[0.09] dark:bg-white/[0.04] dark:text-white/55 dark:hover:bg-white/[0.08]"
+								on:click={() => (vehiclePage = Math.max(1, safePage - 1))}
+								disabled={safePage <= 1}
+								aria-label="Página anterior"
 							>
-								<Icon icon="mdi:chevron-left" width={13} aria-hidden="true" />Anterior
+								<Icon icon="mdi:chevron-left" width={14} aria-hidden="true" />
 							</button>
-							<span class="text-[11px] text-slate-500 dark:text-white/35"
-								>Pág. <strong class="text-slate-800 dark:text-white/65">{vehiclePage}</strong> /
-								<strong class="text-slate-800 dark:text-white/65">{totalPages}</strong></span
-							>
+							{#each pageNumbers as p, i (typeof p === 'number' ? p : `e-${i}`)}
+								{#if p === '…'}
+									<span class="px-0.5 text-[11px] text-slate-400">…</span>
+								{:else}
+									<button
+										type="button"
+										class="flex h-7 min-w-7 items-center justify-center rounded-lg border px-1.5 text-[11px] font-semibold transition-colors {safePage ===
+										p
+											? 'border-emerald-500/40 bg-emerald-600 text-white'
+											: 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50 dark:border-white/[0.09] dark:bg-white/[0.04] dark:text-white/55 dark:hover:bg-white/[0.08]'}"
+										on:click={() => (vehiclePage = p)}
+										aria-current={safePage === p ? 'page' : undefined}
+										aria-label="Ir a página {p}"
+									>
+										{p}
+									</button>
+								{/if}
+							{/each}
 							<button
 								type="button"
-								class="flex h-7 items-center gap-1 rounded-lg border border-slate-200 bg-white px-2.5 text-[11px] font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-30 dark:border-white/[0.09] dark:bg-white/[0.04] dark:text-white/55 dark:hover:bg-white/[0.08]"
-								on:click={() => (vehiclePage = Math.min(totalPages, vehiclePage + 1))}
-								disabled={vehiclePage === totalPages}
+								class="flex h-7 w-7 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 hover:bg-slate-50 disabled:opacity-30 dark:border-white/[0.09] dark:bg-white/[0.04] dark:text-white/55 dark:hover:bg-white/[0.08]"
+								on:click={() => (vehiclePage = Math.min(totalPages, safePage + 1))}
+								disabled={safePage >= totalPages}
+								aria-label="Página siguiente"
 							>
-								Siguiente<Icon icon="mdi:chevron-right" width={13} aria-hidden="true" />
+								<Icon icon="mdi:chevron-right" width={14} aria-hidden="true" />
 							</button>
 						</div>
-					{/if}
+					</div>
 
 					{#if vehicleToDelete}
 						<div

--- a/src/lib/components/MapContainer.svelte
+++ b/src/lib/components/MapContainer.svelte
@@ -9,7 +9,12 @@
 		isPositionStreamEnabled,
 		startVehiclePositionStream
 	} from '$lib/services/vehiclePositionStream.js';
-	import { vehicles, vehicleActions, activeUnitId } from '$lib/stores/vehicleStore.js';
+	import {
+		vehicles,
+		vehicleActions,
+		activeUnitId,
+		mapVisibleUnitIds
+	} from '$lib/stores/vehicleStore.js';
 	import {
 		showH3Grid,
 		h3Resolution,
@@ -21,7 +26,7 @@
 	import { h3GridOverlayService } from '$lib/services/h3GridOverlayService.js';
 	import { alerts, alarmEvents, unreadAlarmCount, alertActions } from '$lib/stores/alertStore.js';
 	import { theme } from '$lib/stores/themeStore.js';
-	import { get } from 'svelte/store';
+	import { get, derived } from 'svelte/store';
 	import { formatAlarmWhen } from '$lib/utils/alarmFormat.js';
 	import ConfirmModal from './ConfirmModal.svelte';
 
@@ -132,6 +137,9 @@
 			const unsubTheme = theme.subscribe(applyTheme);
 
 			if (get(vehicles).length === 0) await vehicleActions.loadVehicles();
+			else if (get(mapVisibleUnitIds).length === 0 && get(vehicles).length > 0) {
+				vehicleActions.showAllOnMap();
+			}
 
 			/** @type {() => void} */
 			let stopPositionStream = () => {};
@@ -170,7 +178,12 @@
 					.join('\0');
 			}
 
-			const unsubVehicles = vehicles.subscribe((list) => {
+			const mapVehicles = derived([vehicles, mapVisibleUnitIds], ([$vehicles, $visibleIds]) => {
+				const visible = new Set(($visibleIds || []).map(String));
+				return ($vehicles || []).filter((v) => visible.has(String(v.id)));
+			});
+
+			const unsubVehicles = mapVehicles.subscribe((list) => {
 				const key = vehicleListKey(list);
 				if (list.length > 0) {
 					if (key !== lastVehicleIdKey) {
@@ -187,7 +200,7 @@
 				} else {
 					mapService.clearVehicleMarkers();
 					lastVehicleIdKey = '';
-					hasInitiallyCentered = false;
+					// No reset hasInitiallyCentered: evita re-fitBounds al ocultar todos y volver a mostrar
 				}
 				syncPositionStream();
 			});

--- a/src/lib/components/MapVisibleUnitsCard.svelte
+++ b/src/lib/components/MapVisibleUnitsCard.svelte
@@ -1,0 +1,77 @@
+<script>
+	import Icon from '@iconify/svelte';
+	import {
+		vehicles,
+		mapVisibleUnitIds,
+		mapVisibleUnitCount,
+		vehicleActions
+	} from '$lib/stores/vehicleStore.js';
+
+	let collapsed = false;
+
+	$: allOnMap =
+		$vehicles.length > 0 && $vehicles.every((v) => $mapVisibleUnitIds.includes(String(v.id)));
+
+	function toggleAll() {
+		if (allOnMap) vehicleActions.hideAllOnMap();
+		else vehicleActions.showAllOnMap();
+	}
+</script>
+
+<div
+	class="pointer-events-auto w-[220px] overflow-hidden rounded-xl border border-slate-200/90 bg-white/95 shadow-lg backdrop-blur-md dark:border-white/10 dark:bg-[rgb(8_11_22_/0.94)] dark:shadow-[0_12px_40px_rgba(0,0,0,0.55)]"
+	role="region"
+	aria-label="Unidades visibles en el mapa"
+>
+	<div class="flex items-center gap-2 border-b border-slate-100 px-3 py-2 dark:border-white/[0.06]">
+		<p class="m-0 flex-1 text-[12px] font-bold text-slate-900 dark:text-white">Unidades visibles</p>
+		<span
+			class="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700 dark:text-emerald-300"
+		>
+			{$mapVisibleUnitCount}/{$vehicles.length}
+		</span>
+		<button
+			type="button"
+			class="flex h-6 w-6 items-center justify-center rounded-md text-slate-400 hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-white/10 dark:hover:text-white/70"
+			on:click={() => (collapsed = !collapsed)}
+			aria-expanded={!collapsed}
+			aria-label={collapsed ? 'Expandir unidades visibles' : 'Colapsar unidades visibles'}
+		>
+			<Icon icon={collapsed ? 'mdi:chevron-down' : 'mdi:chevron-up'} width={16} />
+		</button>
+	</div>
+
+	{#if !collapsed}
+		<div class="max-h-[220px] overflow-y-auto overscroll-contain px-2 py-2">
+			<label
+				class="mb-1.5 flex cursor-pointer items-center gap-2 rounded-lg px-1.5 py-1 text-[11px] font-medium text-slate-600 hover:bg-slate-50 dark:text-white/55 dark:hover:bg-white/[0.04]"
+			>
+				<input
+					type="checkbox"
+					class="size-3.5 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500"
+					checked={allOnMap}
+					disabled={$vehicles.length === 0}
+					on:change={toggleAll}
+				/>
+				Seleccionar todas ({$vehicles.length})
+			</label>
+			<ul class="m-0 list-none space-y-0.5 p-0">
+				{#each $vehicles as v (v.id)}
+					<li>
+						<label
+							class="flex cursor-pointer items-center gap-2 rounded-lg px-1.5 py-1.5 text-[11px] text-slate-700 hover:bg-slate-50 dark:text-white/75 dark:hover:bg-white/[0.04]"
+						>
+							<input
+								type="checkbox"
+								class="size-3.5 shrink-0 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500"
+								checked={$mapVisibleUnitIds.includes(String(v.id))}
+								on:change={() => vehicleActions.toggleMapVisibility(v.id)}
+							/>
+							<span class="min-w-0 flex-1 truncate font-medium">{v.name}</span>
+						</label>
+					</li>
+				{/each}
+			</ul>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/SecurityConsolePanel.svelte
+++ b/src/lib/components/SecurityConsolePanel.svelte
@@ -10,25 +10,27 @@
 </script>
 
 <div
-	class="pointer-events-auto w-full rounded-t-2xl bg-[#0c1829] shadow-[0_-4px_20px_rgba(0,0,0,0.5)]"
+	class="pointer-events-auto w-full rounded-t-2xl bg-white shadow-[0_-4px_20px_rgba(15,23,42,0.12)] dark:bg-[#0c1829] dark:shadow-[0_-4px_20px_rgba(0,0,0,0.5)]"
 >
 	<div class="flex justify-center py-2">
-		<div class="h-1 w-9 rounded-full bg-white/30"></div>
+		<div class="h-1 w-9 rounded-full bg-slate-300 dark:bg-white/30"></div>
 	</div>
 
-	<div class="flex items-center gap-3 border-b border-white/[0.08] px-4 pb-3">
+	<div class="flex items-center gap-3 border-b border-slate-200 px-4 pb-3 dark:border-white/[0.08]">
 		<div
 			class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-red-600/20 text-red-400"
 		>
 			<ShieldBoltIcon size={22} variant="red" />
 		</div>
 		<div class="min-w-0 flex-1">
-			<h2 class="m-0 text-[17px] font-bold text-white">Consola de Seguridad</h2>
-			<p class="m-0 truncate text-[13px] text-white/50">{unit?.name || 'Unidad'}</p>
+			<h2 class="m-0 text-[17px] font-bold text-slate-900 dark:text-white">Consola de Seguridad</h2>
+			<p class="m-0 truncate text-[13px] text-slate-500 dark:text-white/50">
+				{unit?.name || 'Unidad'}
+			</p>
 		</div>
 		<button
 			type="button"
-			class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-white/10 text-white/60 transition-colors hover:bg-white/15 hover:text-white"
+			class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-slate-100 text-slate-500 transition-colors hover:bg-slate-200 hover:text-slate-900 dark:bg-white/10 dark:text-white/60 dark:hover:bg-white/15 dark:hover:text-white"
 			on:click={onBack}
 			aria-label="Cerrar consola de seguridad"
 		>
@@ -37,15 +39,21 @@
 	</div>
 
 	<div class="max-h-[min(68vh,520px)] overflow-y-auto overscroll-contain px-4 py-4 pb-6">
-		<p class="m-0 mb-2 text-[11px] font-bold uppercase tracking-[0.08em] text-white/40">
+		<p
+			class="m-0 mb-2 text-[11px] font-bold uppercase tracking-[0.08em] text-slate-400 dark:text-white/40"
+		>
 			Acciones disponibles
 		</p>
 
-		<div class="rounded-2xl border border-white/[0.08] bg-white/[0.04] p-4">
+		<div
+			class="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-white/[0.08] dark:bg-white/[0.04]"
+		>
 			<div class="mb-3 flex items-start justify-between gap-2">
 				<div class="flex items-center gap-2">
 					<Icon icon="mdi:shield-check" width={18} class="text-sky-400" aria-hidden="true" />
-					<span class="text-[14px] font-bold text-white">Control Remoto de Motor</span>
+					<span class="text-[14px] font-bold text-slate-900 dark:text-white"
+						>Control Remoto de Motor</span
+					>
 				</div>
 				<span
 					class="shrink-0 rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-bold text-emerald-400"
@@ -53,7 +61,7 @@
 					✓ Compatible
 				</span>
 			</div>
-			<p class="m-0 mb-4 text-[12px] text-white/45">
+			<p class="m-0 mb-4 text-[12px] text-slate-500 dark:text-white/45">
 				Modelo registrado: {deviceModel} ({deviceBrand})
 			</p>
 
@@ -83,23 +91,25 @@
 			</div>
 		</div>
 
-		<p class="m-0 mb-2 mt-5 text-[11px] font-bold uppercase tracking-[0.08em] text-white/40">
+		<p
+			class="m-0 mb-2 mt-5 text-[11px] font-bold uppercase tracking-[0.08em] text-slate-400 dark:text-white/40"
+		>
 			Historial de peticiones (auditoría)
 		</p>
 
 		<div
-			class="flex flex-col items-center justify-center rounded-2xl border border-white/[0.08] bg-white/[0.03] px-4 py-10 text-center"
+			class="flex flex-col items-center justify-center rounded-2xl border border-slate-200 bg-slate-50 px-4 py-10 text-center dark:border-white/[0.08] dark:bg-white/[0.03]"
 		>
-			<div class="relative mb-3 text-white/25">
+			<div class="relative mb-3 text-slate-300 dark:text-white/25">
 				<Icon icon="mdi:clock-outline" width={44} aria-hidden="true" />
 				<Icon
 					icon="mdi:check-circle"
 					width={16}
-					class="absolute -bottom-0.5 -right-1 text-white/35"
+					class="absolute -bottom-0.5 -right-1 text-slate-400 dark:text-white/35"
 					aria-hidden="true"
 				/>
 			</div>
-			<p class="m-0 max-w-[280px] text-[12px] leading-relaxed text-white/40">
+			<p class="m-0 max-w-[280px] text-[12px] leading-relaxed text-slate-400 dark:text-white/40">
 				No se registran comandos enviados recientemente a esta unidad desde este dispositivo.
 			</p>
 		</div>

--- a/src/lib/components/TopDrawer.svelte
+++ b/src/lib/components/TopDrawer.svelte
@@ -1,12 +1,13 @@
 <script>
 	import Icon from '@iconify/svelte';
-	import { createEventDispatcher, onDestroy } from 'svelte';
+	import { createEventDispatcher, onDestroy, onMount } from 'svelte';
 	import { fly, fade } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
 	import { browser } from '$app/environment';
 
 	export let open = false;
 	export let title = '';
+	export let subtitle = '';
 	export let icon = '';
 	export let accentColor = '#2563eb';
 	export let sidebarWidth = 72;
@@ -15,8 +16,36 @@
 	export let headerPaddingClass = 'px-6';
 	export let bodyScrollable = true;
 	export let passiveBackdrop = false;
+	/**
+	 * 'bottom' = sheet inferior.
+	 * 'side' = panel izquierdo solo en escritorio (lg+); en tablet usa sheet inferior.
+	 */
+	export let placement = 'bottom';
+
+	const DESKTOP_MQ = '(min-width: 1024px)';
 
 	const dispatch = createEventDispatcher();
+
+	/** @type {boolean} */
+	let isDesktopUp =
+		browser && typeof window !== 'undefined' && window.matchMedia(DESKTOP_MQ).matches;
+
+	/** @type {MediaQueryList | null} */
+	let desktopMq = null;
+
+	function syncDesktopMq() {
+		isDesktopUp = !!desktopMq?.matches;
+	}
+
+	onMount(() => {
+		if (!browser) return;
+		desktopMq = window.matchMedia(DESKTOP_MQ);
+		syncDesktopMq();
+		desktopMq.addEventListener('change', syncDesktopMq);
+		return () => desktopMq?.removeEventListener('change', syncDesktopMq);
+	});
+
+	$: resolvedPlacement = placement === 'side' && isDesktopUp ? 'side' : 'bottom';
 
 	function slugify(s) {
 		return (
@@ -70,14 +99,19 @@
 		transition:fade={{ duration: 200 }}
 	>
 		<div
-			class="pointer-events-auto absolute left-0 right-0 top-0 flex h-[clamp(520px,74vh,860px)] max-h-[860px] flex-col overflow-hidden border-b border-slate-200 bg-white/95 text-slate-900 shadow-xl backdrop-blur-[40px] [-webkit-backdrop-filter:blur(40px)] dark:border-white/[0.07] dark:bg-[rgb(8_11_22_/0.97)] dark:text-white dark:shadow-[0_24px_80px_rgba(0,0,0,0.75),0_4px_20px_rgba(0,0,0,0.5),inset_0_1px_0_rgba(255,255,255,0.05)]"
+			class="pointer-events-auto absolute flex flex-col overflow-hidden bg-white/95 text-slate-900 shadow-xl backdrop-blur-[40px] [-webkit-backdrop-filter:blur(40px)] dark:bg-[rgb(8_11_22_/0.97)] dark:text-white dark:shadow-[0_24px_80px_rgba(0,0,0,0.75),0_4px_20px_rgba(0,0,0,0.5),inset_0_1px_0_rgba(255,255,255,0.05)] {resolvedPlacement ===
+			'side'
+				? 'left-0 top-0 bottom-0 w-[min(420px,40%)] max-w-[480px] border-r border-slate-200 dark:border-white/[0.07]'
+				: 'left-0 right-0 bottom-0 h-[50vh] max-h-[50vh] overflow-y-auto rounded-t-2xl border-t border-slate-200 dark:border-white/[0.07]'}"
 			role="dialog"
 			aria-modal="true"
 			aria-labelledby={headingIdResolved}
 			tabindex="-1"
 			on:click|stopPropagation
 			on:keydown|stopPropagation={(e) => e.stopPropagation()}
-			transition:fly={{ y: -20, duration: 380, easing: cubicOut, opacity: 0.95 }}
+			transition:fly={resolvedPlacement === 'side'
+				? { x: -24, duration: 320, easing: cubicOut, opacity: 0.96 }
+				: { y: 20, duration: 380, easing: cubicOut, opacity: 0.95 }}
 		>
 			<div
 				class="h-0.5 shrink-0 opacity-80"
@@ -110,6 +144,9 @@
 						>
 							{title}
 						</h2>
+						{#if subtitle}
+							<p class="m-0 mt-0.5 text-[12px] text-slate-500 dark:text-white/45">{subtitle}</p>
+						{/if}
 					</div>
 				</div>
 				<button

--- a/src/lib/components/TrackingContextPanel.svelte
+++ b/src/lib/components/TrackingContextPanel.svelte
@@ -81,12 +81,12 @@
 		signalLevel == null
 			? ''
 			: signalLevel === 0
-				? 'text-red-400'
+				? 'text-red-500 dark:text-red-400'
 				: signalLevel === 1
-					? 'text-orange-400'
+					? 'text-orange-500 dark:text-orange-400'
 					: signalLevel === 2
-						? 'text-yellow-400'
-						: 'text-emerald-400';
+						? 'text-amber-500 dark:text-yellow-400'
+						: 'text-emerald-600 dark:text-emerald-400';
 	$: isOnline = engineOn || isMoving;
 	$: isFollowing = Boolean(unit && $followedVehicleId === unit.id);
 	function handleSelectUnit(u) {
@@ -107,34 +107,37 @@
 
 {#if unit}
 	<div
-		class="pointer-events-auto w-full rounded-t-2xl bg-[#0c1829] shadow-[0_-4px_20px_rgba(0,0,0,0.5)]"
+		class="pointer-events-auto w-full rounded-t-2xl border border-slate-200/80 bg-white shadow-[0_-4px_20px_rgba(15,23,42,0.12)] dark:border-transparent dark:bg-[#0c1829] dark:shadow-[0_-4px_20px_rgba(0,0,0,0.5)]"
 	>
 		<!-- Grabber -->
 		<div class="flex justify-center py-2">
-			<div class="h-1 w-9 rounded-full bg-white/30"></div>
+			<div class="h-1 w-9 rounded-full bg-slate-300 dark:bg-white/30"></div>
 		</div>
 		<!-- Unit info -->
 		<div class="px-4 pb-3">
 			<div class="flex items-start gap-3">
 				<div class="min-w-0 flex-1">
-					<h2 class="m-0 truncate text-xl font-bold text-white">{unit.name}</h2>
-					<p class="m-0 text-sm text-white/60">
+					<h2 class="m-0 truncate text-xl font-bold text-slate-900 dark:text-white">{unit.name}</h2>
+					<p class="m-0 text-sm text-slate-500 dark:text-white/60">
 						{[unit.brand, unit.model].filter(Boolean).join(' ') || 'Sin modelo'}
 					</p>
 					<p class="m-0 mt-1 flex items-center gap-1.5 text-sm">
 						<span
 							class="h-2 w-2 rounded-full {isOnline
-								? 'bg-emerald-400'
+								? 'bg-emerald-500 dark:bg-emerald-400'
 								: hasSignal
 									? 'bg-amber-500'
 									: 'bg-red-500'}"
 						></span>
 						<span
-							class={isOnline ? 'text-emerald-400' : hasSignal ? 'text-amber-500' : 'text-red-500'}
-							>{statusLabel}</span
+							class={isOnline
+								? 'text-emerald-600 dark:text-emerald-400'
+								: hasSignal
+									? 'text-amber-600 dark:text-amber-500'
+									: 'text-red-600 dark:text-red-500'}>{statusLabel}</span
 						>
 						{#if dateLabel}
-							<span class="text-white/40">- {dateLabel}</span>
+							<span class="text-slate-400 dark:text-white/40">- {dateLabel}</span>
 						{/if}
 					</p>
 					<button
@@ -154,7 +157,7 @@
 						/>
 						{isFollowing ? 'Siguiendo' : 'Seguir'}
 					</button>
-					<div class="mt-1 flex items-center gap-1 text-xs text-white/50">
+					<div class="mt-1 flex items-center gap-1 text-xs text-slate-500 dark:text-white/50">
 						<Icon icon="mdi:car-battery" class="h-3.5 w-3.5" />
 						<span>{mainBattery}</span>
 						<Icon icon="mdi:battery-outline" class="ml-1 h-3.5 w-3.5" />
@@ -180,7 +183,7 @@
 					</button>
 					<button
 						type="button"
-						class="flex h-11 w-11 items-center justify-center rounded-full border border-red-500/30 bg-red-600/90 shadow-lg shadow-red-900/30 transition-transform hover:scale-105"
+						class="flex h-11 w-11 items-center justify-center rounded-full border border-red-500/30 bg-red-600/90 shadow-lg shadow-red-900/20 transition-transform hover:scale-105 dark:shadow-red-900/30"
 						on:click={onOpenSecurity}
 						aria-label="Consola de seguridad"
 						title="Consola de seguridad"
@@ -194,60 +197,62 @@
 		{#if units.length > 1}
 			<button
 				type="button"
-				class="flex w-full items-center justify-between gap-2 border-t border-white/10 bg-white/5 px-4 py-2.5"
+				class="flex w-full items-center justify-between gap-2 border-t border-slate-200 bg-slate-50 px-4 py-2.5 dark:border-white/10 dark:bg-white/5"
 				on:click={() => (showUnitPicker = !showUnitPicker)}
 				aria-expanded={showUnitPicker}
 			>
 				<div class="flex items-center gap-2">
 					<span
 						class="h-2.5 w-2.5 rounded-full {isOnline
-							? 'bg-emerald-400'
+							? 'bg-emerald-500 dark:bg-emerald-400'
 							: hasSignal
 								? 'bg-amber-500'
 								: 'bg-red-500'}"
 					></span>
-					<span class="text-sm font-medium text-white">{unit.name}</span>
+					<span class="text-sm font-medium text-slate-900 dark:text-white">{unit.name}</span>
 					<span
-						class="rounded-full bg-white/10 px-1.5 py-0.5 text-[10px] font-semibold text-white/70"
+						class="rounded-full bg-slate-200 px-1.5 py-0.5 text-[10px] font-semibold text-slate-600 dark:bg-white/10 dark:text-white/70"
 						>{units.length}</span
 					>
 				</div>
 				<Icon
 					icon={showUnitPicker ? 'mdi:chevron-up' : 'mdi:chevron-down'}
-					class="h-5 w-5 text-white/50"
+					class="h-5 w-5 text-slate-400 dark:text-white/50"
 				/>
 			</button>
 		{/if}
 		<!-- Unit picker list -->
 		{#if showUnitPicker}
-			<div class="border-t border-white/10 px-3 pb-3 pt-2">
+			<div class="border-t border-slate-200 px-3 pb-3 pt-2 dark:border-white/10">
 				<input
 					type="search"
 					bind:value={searchQuery}
 					placeholder="Buscar unidad…"
-					class="mb-2.5 w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-[13px] text-white placeholder:text-white/30 outline-none focus:border-sky-500/50"
+					class="mb-2.5 w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-[13px] text-slate-900 placeholder:text-slate-400 outline-none focus:border-sky-500/50 dark:border-white/10 dark:bg-white/5 dark:text-white dark:placeholder:text-white/30"
 				/>
 				<div class="mb-2.5">
 					<UnitsStatusFilterPanels {units} bind:value={statusFilter} variant="embedded" />
 				</div>
-				<ul class="m-0 max-h-[220px] list-none overflow-y-auto overscroll-contain p-0 space-y-0.5">
+				<ul class="m-0 max-h-[220px] list-none space-y-0.5 overflow-y-auto overscroll-contain p-0">
 					{#each filteredUnits as u (u.id)}
 						{@const st = getUnitTrackingStatus(u)}
 						{@const dt = formatUnitStatusDate(u)}
 						<li>
 							<button
 								type="button"
-								class="flex w-full items-center gap-2.5 rounded-lg px-2 py-2.5 text-left transition-colors hover:bg-white/[0.07] {u.id ===
+								class="flex w-full items-center gap-2.5 rounded-lg px-2 py-2.5 text-left transition-colors hover:bg-slate-100 dark:hover:bg-white/[0.07] {u.id ===
 								unit.id
-									? 'bg-white/[0.08]'
+									? 'bg-slate-100 dark:bg-white/[0.08]'
 									: ''}"
 								on:click={() => handleSelectUnit(u)}
 							>
 								<span class="h-2 w-2 shrink-0 rounded-full {st.dotClass}"></span>
 								<div class="min-w-0 flex-1">
-									<p class="m-0 truncate text-[13px] font-semibold text-white">{u.name}</p>
+									<p class="m-0 truncate text-[13px] font-semibold text-slate-900 dark:text-white">
+										{u.name}
+									</p>
 									{#if dt}
-										<p class="m-0 text-[10px] text-white/35">{dt}</p>
+										<p class="m-0 text-[10px] text-slate-400 dark:text-white/35">{dt}</p>
 									{/if}
 								</div>
 								<span class="shrink-0 text-[11px] font-semibold {st.colorClass}"
@@ -260,15 +265,15 @@
 			</div>
 		{/if}
 		<!-- Action buttons -->
-		<div class="border-t border-white/10 px-3 py-2">
+		<div class="border-t border-slate-200 px-3 py-2 dark:border-white/10">
 			<div class="grid grid-cols-4 gap-1">
 				{#each panelActions as action (action.id)}
 					<button
 						type="button"
-						class="flex flex-col items-center gap-1 rounded-xl px-1 py-2 text-center transition-colors hover:bg-white/[0.07] {panelView ===
+						class="flex flex-col items-center gap-1 rounded-xl px-1 py-2 text-center transition-colors hover:bg-slate-100 dark:hover:bg-white/[0.07] {panelView ===
 						action.id
-							? 'bg-white/[0.1] text-white'
-							: 'text-white/50'}"
+							? 'bg-slate-100 text-slate-900 dark:bg-white/[0.1] dark:text-white'
+							: 'text-slate-700 dark:text-white/50'}"
 						on:click={() => onPanelViewChange(action.id)}
 						aria-pressed={panelView === action.id}
 					>
@@ -283,17 +288,37 @@
 
 <style>
 	.follow-toggle-btn {
+		border-color: rgba(148, 163, 184, 0.45);
+		background: rgba(241, 245, 249, 0.95);
+		color: rgba(71, 85, 105, 0.9);
+	}
+	.follow-toggle-btn.following {
+		border-color: rgba(14, 165, 233, 0.45);
+		background: rgba(14, 165, 233, 0.1);
+		color: #0284c7;
+		animation: follow-toggle-glow 1.8s ease-in-out infinite;
+	}
+	:global(html.dark) .follow-toggle-btn {
 		border-color: rgba(148, 163, 184, 0.25);
 		background: rgba(148, 163, 184, 0.08);
 		color: rgba(226, 232, 240, 0.65);
 	}
-	.follow-toggle-btn.following {
+	:global(html.dark) .follow-toggle-btn.following {
 		border-color: rgba(0, 166, 192, 0.55);
 		background: rgba(0, 166, 192, 0.14);
 		color: #00a6c0;
-		animation: follow-toggle-glow 1.8s ease-in-out infinite;
+		animation-name: follow-toggle-glow-dark;
 	}
 	@keyframes follow-toggle-glow {
+		0%,
+		100% {
+			box-shadow: 0 0 0 0 rgba(14, 165, 233, 0.3);
+		}
+		50% {
+			box-shadow: 0 0 10px 2px rgba(14, 165, 233, 0.3);
+		}
+	}
+	@keyframes follow-toggle-glow-dark {
 		0%,
 		100% {
 			box-shadow: 0 0 0 0 rgba(0, 166, 192, 0.35);

--- a/src/lib/components/TripDetailView.svelte
+++ b/src/lib/components/TripDetailView.svelte
@@ -9,11 +9,19 @@
 	let isPlaying = false;
 	let showAlerts = false;
 	let playbackProgress = 0;
+	/** En móvil: resumen de métricas colapsado para dejar más mapa visible. */
+	let statsExpanded = false;
+	/** @type {string | null} */
+	let _statsTripId = null;
 
 	$: distance = trip?.distance_km != null ? `${trip.distance_km.toFixed(1)} km` : '--';
 	$: duration = formatDuration(trip?.duration_minutes);
 	$: alertsCount = trip?.alerts?.length || 0;
 	$: pointsCount = trip?.points?.length || 0;
+	$: if (trip?.id !== _statsTripId) {
+		_statsTripId = trip?.id ?? null;
+		statsExpanded = false;
+	}
 
 	function formatDuration(minutes) {
 		if (minutes == null) return '--';
@@ -75,21 +83,21 @@
 	}
 </script>
 
-<div class="flex h-full flex-col bg-[#0c1829]">
+<div class="flex h-full flex-col bg-white dark:bg-[#0c1829]">
 	<!-- Header -->
 	<div class="flex items-center justify-between px-4 py-3">
 		<button
 			type="button"
-			class="flex h-10 w-10 items-center justify-center rounded-full text-white/70 hover:bg-white/10"
+			class="flex h-10 w-10 items-center justify-center rounded-full text-slate-600 hover:bg-slate-100 dark:text-white/70 dark:hover:bg-white/10"
 			on:click={handleBack}
 			aria-label="Volver"
 		>
 			<Icon icon="mdi:chevron-left" width={28} />
 		</button>
-		<h2 class="text-lg font-semibold text-white">Detalle del Trayecto</h2>
+		<h2 class="text-lg font-semibold text-slate-900 dark:text-white">Detalle del Trayecto</h2>
 		<button
 			type="button"
-			class="flex h-10 w-10 items-center justify-center rounded-full text-white/70 hover:bg-white/10"
+			class="flex h-10 w-10 items-center justify-center rounded-full text-slate-600 hover:bg-slate-100 dark:text-white/70 dark:hover:bg-white/10"
 			on:click={handleClose}
 			aria-label="Cerrar"
 		>
@@ -103,12 +111,12 @@
 			<div class="flex-1">
 				<p
 					class="text-xs font-semibold uppercase tracking-wide {isPlaying
-						? 'text-cyan-400'
-						: 'text-white/50'}"
+						? 'text-cyan-600 dark:text-cyan-400'
+						: 'text-slate-500 dark:text-white/50'}"
 				>
 					{isPlaying ? 'Reproduciendo' : 'Trayecto'}
 				</p>
-				<p class="text-sm text-white/70">Controles en vivo</p>
+				<p class="text-sm text-slate-600 dark:text-white/70">Controles en vivo</p>
 			</div>
 
 			<!-- Play/Pause -->
@@ -116,11 +124,15 @@
 				type="button"
 				class="flex h-12 w-12 items-center justify-center rounded-full {isPlaying
 					? 'bg-cyan-500'
-					: 'bg-white/10'} transition-colors"
+					: 'bg-slate-200 dark:bg-white/10'} transition-colors"
 				on:click={togglePlay}
 				aria-label={isPlaying ? 'Pausar' : 'Reproducir'}
 			>
-				<Icon icon={isPlaying ? 'mdi:pause' : 'mdi:play'} width={24} class="text-white" />
+				<Icon
+					icon={isPlaying ? 'mdi:pause' : 'mdi:play'}
+					width={24}
+					class={isPlaying ? 'text-white' : 'text-slate-700 dark:text-white'}
+				/>
 			</button>
 
 			<!-- Stop -->
@@ -140,27 +152,31 @@
 				type="button"
 				class="flex h-12 w-12 items-center justify-center rounded-full {showAlerts
 					? 'bg-amber-500'
-					: 'bg-white/10'} transition-colors"
+					: 'bg-slate-200 dark:bg-white/10'} transition-colors"
 				on:click={toggleAlerts}
 				aria-label={showAlerts ? 'Ocultar alertas' : 'Mostrar alertas'}
 			>
-				<Icon icon="mdi:alert" width={24} class="text-white" />
+				<Icon
+					icon="mdi:alert"
+					width={24}
+					class={showAlerts ? 'text-white' : 'text-slate-700 dark:text-white'}
+				/>
 			</button>
 
 			<!-- Center -->
 			<button
 				type="button"
-				class="flex h-12 w-12 items-center justify-center rounded-full bg-white/10 transition-colors hover:bg-white/20"
+				class="flex h-12 w-12 items-center justify-center rounded-full bg-slate-200 transition-colors hover:bg-slate-200 dark:bg-white/10 dark:hover:bg-white/20"
 				on:click={centerOnRoute}
 				aria-label="Centrar en ruta"
 			>
-				<Icon icon="mdi:crosshairs-gps" width={24} class="text-white" />
+				<Icon icon="mdi:crosshairs-gps" width={24} class="text-slate-700 dark:text-white" />
 			</button>
 		</div>
 
 		<!-- Progress bar -->
 		{#if isPlaying || playbackProgress > 0}
-			<div class="mt-3 h-1 overflow-hidden rounded-full bg-white/10">
+			<div class="mt-3 h-1 overflow-hidden rounded-full bg-slate-100 dark:bg-white/10">
 				<div
 					class="h-full bg-cyan-400 transition-all duration-100"
 					style="width: {playbackProgress * 100}%"
@@ -169,34 +185,68 @@
 		{/if}
 	</div>
 
-	<!-- Stats Grid -->
-	<div class="grid grid-cols-2 gap-3 px-4 pb-4">
-		<!-- Distance -->
-		<div class="flex flex-col items-center justify-center rounded-2xl bg-white/5 py-4">
-			<Icon icon="mdi:swap-horizontal" width={28} class="text-cyan-400" />
-			<p class="mt-2 text-xl font-bold text-white">{distance}</p>
-			<p class="text-xs text-white/50">Distancia</p>
-		</div>
+	<!-- Stats: en móvil colapsable (cerrado al abrir); en sm+ siempre visible -->
+	<div class="px-4 pb-4">
+		<button
+			type="button"
+			class="flex w-full items-center justify-between gap-2 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2.5 text-left sm:hidden dark:border-white/10 dark:bg-white/[0.05]"
+			on:click={() => (statsExpanded = !statsExpanded)}
+			aria-expanded={statsExpanded}
+		>
+			<div class="min-w-0">
+				<p
+					class="m-0 text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-white/45"
+				>
+					Resumen
+				</p>
+				<p class="m-0 truncate text-[13px] text-slate-700 dark:text-white/70">
+					{distance} · {duration} · {alertsCount} alertas
+				</p>
+			</div>
+			<Icon
+				icon={statsExpanded ? 'mdi:chevron-up' : 'mdi:chevron-down'}
+				width={22}
+				class="shrink-0 text-slate-500 dark:text-white/50"
+				aria-hidden="true"
+			/>
+		</button>
 
-		<!-- Duration -->
-		<div class="flex flex-col items-center justify-center rounded-2xl bg-white/5 py-4">
-			<Icon icon="mdi:clock-outline" width={28} class="text-cyan-400" />
-			<p class="mt-2 text-xl font-bold text-white">{duration}</p>
-			<p class="text-xs text-white/50">Duración</p>
-		</div>
+		<div class="grid grid-cols-2 gap-3 {statsExpanded ? 'mt-3' : 'hidden'} sm:mt-0 sm:grid">
+			<!-- Distance -->
+			<div
+				class="flex flex-col items-center justify-center rounded-2xl bg-slate-50 py-4 dark:bg-white/5"
+			>
+				<Icon icon="mdi:swap-horizontal" width={28} class="text-cyan-600 dark:text-cyan-400" />
+				<p class="mt-2 text-xl font-bold text-slate-900 dark:text-white">{distance}</p>
+				<p class="text-xs text-slate-500 dark:text-white/50">Distancia</p>
+			</div>
 
-		<!-- Alerts -->
-		<div class="flex flex-col items-center justify-center rounded-2xl bg-white/5 py-4">
-			<Icon icon="mdi:alert-outline" width={28} class="text-amber-400" />
-			<p class="mt-2 text-xl font-bold text-white">{alertsCount}</p>
-			<p class="text-xs text-white/50">Alertas</p>
-		</div>
+			<!-- Duration -->
+			<div
+				class="flex flex-col items-center justify-center rounded-2xl bg-slate-50 py-4 dark:bg-white/5"
+			>
+				<Icon icon="mdi:clock-outline" width={28} class="text-cyan-600 dark:text-cyan-400" />
+				<p class="mt-2 text-xl font-bold text-slate-900 dark:text-white">{duration}</p>
+				<p class="text-xs text-slate-500 dark:text-white/50">Duración</p>
+			</div>
 
-		<!-- Points -->
-		<div class="flex flex-col items-center justify-center rounded-2xl bg-white/5 py-4">
-			<Icon icon="mdi:map-marker-multiple" width={28} class="text-emerald-400" />
-			<p class="mt-2 text-xl font-bold text-white">{pointsCount}</p>
-			<p class="text-xs text-white/50">Puntos</p>
+			<!-- Alerts -->
+			<div
+				class="flex flex-col items-center justify-center rounded-2xl bg-slate-50 py-4 dark:bg-white/5"
+			>
+				<Icon icon="mdi:alert-outline" width={28} class="text-amber-400" />
+				<p class="mt-2 text-xl font-bold text-slate-900 dark:text-white">{alertsCount}</p>
+				<p class="text-xs text-slate-500 dark:text-white/50">Alertas</p>
+			</div>
+
+			<!-- Points -->
+			<div
+				class="flex flex-col items-center justify-center rounded-2xl bg-slate-50 py-4 dark:bg-white/5"
+			>
+				<Icon icon="mdi:map-marker-multiple" width={28} class="text-emerald-400" />
+				<p class="mt-2 text-xl font-bold text-slate-900 dark:text-white">{pointsCount}</p>
+				<p class="text-xs text-slate-500 dark:text-white/50">Puntos</p>
+			</div>
 		</div>
 	</div>
 </div>

--- a/src/lib/components/TripHistoryPanel.svelte
+++ b/src/lib/components/TripHistoryPanel.svelte
@@ -104,27 +104,27 @@
 	<TripDetailView trip={$selectedTrip} onBack={handleBackFromDetail} onClose={handleClose} />
 {:else}
 	<div class="flex h-full flex-col">
-		<div class="flex items-center gap-2 border-b border-white/10 px-3 py-2">
+		<div class="flex items-center gap-2 border-b border-slate-200 px-3 py-2 dark:border-white/10">
 			<button
 				type="button"
-				class="flex h-8 w-8 items-center justify-center rounded-lg text-white/60 hover:bg-white/10"
+				class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100 dark:text-white/60 dark:hover:bg-white/10"
 				on:click={handleBack}
 				aria-label="Volver"
 			>
 				<Icon icon="mdi:arrow-left" width={20} />
 			</button>
 			<div class="flex-1">
-				<p class="m-0 text-sm font-semibold text-white">Trayectos</p>
-				<p class="m-0 text-[11px] text-white/50">{unit?.name || 'Unidad'}</p>
+				<p class="m-0 text-sm font-semibold text-slate-900 dark:text-white">Trayectos</p>
+				<p class="m-0 text-[11px] text-slate-500 dark:text-white/50">{unit?.name || 'Unidad'}</p>
 			</div>
 		</div>
 
-		<div class="border-b border-white/10 px-3 py-2">
+		<div class="border-b border-slate-200 px-3 py-2 dark:border-white/10">
 			<input
 				type="date"
 				bind:value={selectedDate}
 				on:change={handleDateChange}
-				class="w-full rounded-lg border border-white/15 bg-white/5 px-3 py-2 text-sm text-white"
+				class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 dark:border-white/15 dark:bg-white/5 dark:text-white"
 			/>
 		</div>
 
@@ -138,12 +138,12 @@
 			{:else if $tripError}
 				<div class="flex h-32 flex-col items-center justify-center gap-2 px-4 text-center">
 					<Icon icon="mdi:alert-circle-outline" width={28} class="text-red-400" />
-					<p class="m-0 text-xs text-white/50">{$tripError}</p>
+					<p class="m-0 text-xs text-slate-500 dark:text-white/50">{$tripError}</p>
 				</div>
 			{:else if $trips.length === 0}
 				<div class="flex h-32 flex-col items-center justify-center gap-2 px-4 text-center">
-					<Icon icon="mdi:map-marker-path" width={28} class="text-white/25" />
-					<p class="m-0 text-xs text-white/50">Sin trayectos para esta fecha</p>
+					<Icon icon="mdi:map-marker-path" width={28} class="text-slate-300 dark:text-white/25" />
+					<p class="m-0 text-xs text-slate-500 dark:text-white/50">Sin trayectos para esta fecha</p>
 				</div>
 			{:else}
 				<ul class="m-0 list-none space-y-2 p-3">
@@ -151,19 +151,25 @@
 						<li>
 							<button
 								type="button"
-								class="flex w-full items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-left transition-colors hover:border-cyan-400/30 hover:bg-white/10"
+								class="flex w-full items-center gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-left transition-colors hover:border-cyan-400/30 hover:bg-slate-100 dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10"
 								on:click={() => selectTrip(trip)}
 							>
 								<div
 									class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-cyan-400/15"
 								>
-									<Icon icon="mdi:clock-outline" width={20} class="text-cyan-400" />
+									<Icon
+										icon="mdi:clock-outline"
+										width={20}
+										class="text-cyan-600 dark:text-cyan-400"
+									/>
 								</div>
 								<div class="min-w-0 flex-1">
-									<p class="m-0 text-[15px] font-semibold text-white">
+									<p class="m-0 text-[15px] font-semibold text-slate-900 dark:text-white">
 										{formatTime(trip.start_timestamp)} - {formatTime(trip.end_timestamp)}
 									</p>
-									<div class="mt-1 flex items-center gap-4 text-xs text-white/50">
+									<div
+										class="mt-1 flex items-center gap-4 text-xs text-slate-500 dark:text-white/50"
+									>
 										<span class="flex items-center gap-1">
 											<Icon icon="mdi:swap-horizontal" width={14} />
 											{formatDistance(trip.distance_km)}
@@ -174,7 +180,11 @@
 										</span>
 									</div>
 								</div>
-								<Icon icon="mdi:chevron-right" width={20} class="text-white/30" />
+								<Icon
+									icon="mdi:chevron-right"
+									width={20}
+									class="text-slate-400 dark:text-white/30"
+								/>
 							</button>
 						</li>
 					{/each}

--- a/src/lib/components/Unit/UnitProfileDetails.svelte
+++ b/src/lib/components/Unit/UnitProfileDetails.svelte
@@ -53,16 +53,16 @@
 	$: isDrawer = variant === 'drawer';
 	$: sectionLabelClass = isDrawer
 		? 'mb-2 text-[11px] font-bold uppercase tracking-wider text-cyan-600 dark:text-cyan-400/80'
-		: 'mb-2 text-[12px] font-bold uppercase tracking-wider text-cyan-400/80';
+		: 'mb-2 text-[12px] font-bold uppercase tracking-wider text-cyan-600 dark:text-cyan-400/80';
 	$: fieldLabelClass = isDrawer
 		? 'w-[100px] shrink-0 text-[12px] text-slate-500 dark:text-white/40'
-		: 'w-[100px] shrink-0 text-[14px] text-white/40';
+		: 'w-[100px] shrink-0 text-[14px] text-slate-500 dark:text-white/40';
 	$: fieldValueClass = isDrawer
 		? 'text-[12px] font-medium text-slate-800 dark:text-white/90'
-		: 'text-[14px] font-medium text-white/90';
+		: 'text-[14px] font-medium text-slate-800 dark:text-white/90';
 	$: fieldEmptyClass = isDrawer
 		? 'text-[12px] font-medium text-slate-400 dark:text-white/30'
-		: 'text-[14px] font-medium text-white/30';
+		: 'text-[14px] font-medium text-slate-400 dark:text-white/30';
 </script>
 
 {#if loading}
@@ -73,44 +73,30 @@
 	</div>
 {:else if error}
 	<div
-		class="flex h-28 flex-col items-center justify-center gap-2 px-4 text-center {isDrawer
-			? 'text-slate-500 dark:text-white/45'
-			: ''}"
+		class="flex h-28 flex-col items-center justify-center gap-2 px-4 text-center text-slate-500 dark:text-white/45"
 	>
 		<Icon
 			icon="mdi:alert-circle-outline"
 			width={28}
-			class={isDrawer ? 'opacity-40' : 'text-white/25'}
+			class="text-slate-300 opacity-40 dark:text-white/25"
 		/>
-		<p class="m-0 text-xs {isDrawer ? '' : 'text-white/45'}">{error}</p>
+		<p class="m-0 text-xs">{error}</p>
 	</div>
 {:else}
 	<div
-		class="mx-4 mb-4 flex items-center gap-4 rounded-2xl border p-4 {isDrawer
-			? 'border-slate-200 bg-white dark:border-white/10 dark:bg-white/[0.04]'
-			: 'border-white/10 bg-white/[0.05]'}"
+		class="mx-4 mb-4 flex items-center gap-4 rounded-2xl border border-slate-200 bg-white p-4 dark:border-white/10 dark:bg-white/[0.05]"
 	>
 		<div
-			class="flex h-16 w-16 shrink-0 items-center justify-center rounded-xl {isDrawer
-				? 'bg-slate-100 dark:bg-white/[0.06]'
-				: 'bg-white/[0.06]'}"
+			class="flex h-16 w-16 shrink-0 items-center justify-center rounded-xl bg-slate-100 dark:bg-white/[0.06]"
 		>
 			<ColoredVehicleIcon src={iconSrc} colorHex={iconColorHex} sizeClass="h-12 w-12" />
 		</div>
 		<div class="min-w-0 flex-1">
-			<p
-				class="m-0 text-[17px] font-bold leading-tight {isDrawer
-					? 'text-slate-900 dark:text-white'
-					: 'text-white'}"
-			>
+			<p class="m-0 text-[17px] font-bold leading-tight text-slate-900 dark:text-white">
 				{displayName}
 			</p>
 			{#if description}
-				<p
-					class="m-0 mt-1 text-[13px] {isDrawer
-						? 'text-slate-600 dark:text-white/50'
-						: 'text-white/50'}"
-				>
+				<p class="m-0 mt-1 text-[13px] text-slate-600 dark:text-white/50">
 					{description}
 				</p>
 			{/if}

--- a/src/lib/components/UnitDetailsPanel.svelte
+++ b/src/lib/components/UnitDetailsPanel.svelte
@@ -7,15 +7,17 @@
 	export let onClose = () => {};
 </script>
 
-<div class="flex max-h-[70vh] flex-col bg-[#0c1829]">
+<div class="flex max-h-[70vh] flex-col bg-white dark:bg-[#0c1829]">
 	<div class="shrink-0 pt-2 pb-3 px-4">
-		<div class="mx-auto mb-2 h-1.5 w-10 rounded-full bg-white/20"></div>
+		<div class="mx-auto mb-2 h-1.5 w-10 rounded-full bg-slate-300 dark:bg-white/30"></div>
 		<div class="flex items-center">
 			<div class="h-7 w-7 opacity-0" aria-hidden="true"></div>
-			<p class="flex-1 text-center text-[17px] font-bold text-white">Detalles de la Unidad</p>
+			<p class="flex-1 text-center text-[17px] font-bold text-slate-900 dark:text-white">
+				Detalles de la Unidad
+			</p>
 			<button
 				type="button"
-				class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-white/50 hover:text-white/80"
+				class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-slate-500 hover:text-slate-700 dark:text-white/50 dark:hover:text-white/80"
 				on:click={onClose}
 				aria-label="Cerrar"
 			>

--- a/src/lib/components/UnitEventsPanel.svelte
+++ b/src/lib/components/UnitEventsPanel.svelte
@@ -30,23 +30,23 @@
 	}
 </script>
 
-<div class="flex max-h-[70vh] flex-col bg-[#0c1829]">
-	<div class="flex items-center gap-2 border-b border-white/10 px-3 py-2">
+<div class="flex max-h-[70vh] flex-col bg-white dark:bg-[#0c1829]">
+	<div class="flex items-center gap-2 border-b border-slate-200 px-3 py-2 dark:border-white/10">
 		<button
 			type="button"
-			class="flex h-8 w-8 items-center justify-center rounded-lg text-white/60 hover:bg-white/10"
+			class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100 dark:text-white/60 dark:hover:bg-white/10"
 			on:click={onBack}
 			aria-label="Volver"
 		>
 			<Icon icon="mdi:arrow-left" width={20} />
 		</button>
 		<div class="flex-1">
-			<p class="m-0 text-sm font-semibold text-white">Eventos (48h)</p>
-			<p class="m-0 text-[11px] text-white/50">{unit?.name || 'Unidad'}</p>
+			<p class="m-0 text-sm font-semibold text-slate-900 dark:text-white">Eventos (48h)</p>
+			<p class="m-0 text-[11px] text-slate-500 dark:text-white/50">{unit?.name || 'Unidad'}</p>
 		</div>
 		<button
 			type="button"
-			class="flex h-8 w-8 items-center justify-center rounded-lg text-white/50 hover:bg-white/10"
+			class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100 dark:text-white/50 dark:hover:bg-white/10"
 			on:click={refresh}
 			aria-label="Actualizar eventos"
 			disabled={$loadingEvents}
@@ -65,10 +65,10 @@
 		{:else if $eventsError}
 			<div class="flex h-40 flex-col items-center justify-center gap-3 px-4 text-center">
 				<Icon icon="mdi:alert-circle-outline" width={32} class="text-amber-400" />
-				<p class="m-0 text-xs text-white/60">{$eventsError}</p>
+				<p class="m-0 text-xs text-slate-500 dark:text-white/60">{$eventsError}</p>
 				<button
 					type="button"
-					class="rounded-lg bg-cyan-600/20 px-4 py-2 text-xs font-semibold text-cyan-300"
+					class="rounded-lg bg-cyan-600/20 px-4 py-2 text-xs font-semibold text-cyan-600 dark:text-cyan-300"
 					on:click={refresh}
 				>
 					Reintentar
@@ -76,14 +76,18 @@
 			</div>
 		{:else if $unitEvents.length === 0}
 			<div class="flex h-40 flex-col items-center justify-center gap-2 px-4 text-center">
-				<Icon icon="mdi:bell-off-outline" width={36} class="text-white/20" />
-				<p class="m-0 text-sm font-medium text-white/80">Sin eventos recientes</p>
-				<p class="m-0 text-xs text-white/45">Las últimas 48 h están despejadas</p>
+				<Icon icon="mdi:bell-off-outline" width={36} class="text-slate-300 dark:text-white/20" />
+				<p class="m-0 text-sm font-medium text-slate-700 dark:text-white/80">
+					Sin eventos recientes
+				</p>
+				<p class="m-0 text-xs text-slate-500 dark:text-white/45">
+					Las últimas 48 h están despejadas
+				</p>
 			</div>
 		{:else}
 			<ul class="m-0 list-none p-3">
 				{#each $unitEvents as event (event.id)}
-					<li class="border-b border-white/[0.06] last:border-0">
+					<li class="border-b border-slate-100 last:border-0 dark:border-white/[0.06]">
 						<div class="flex gap-3 py-3">
 							<div class="flex flex-col items-center">
 								<div
@@ -93,13 +97,15 @@
 								>
 									<Icon icon={eventIcon(event.eventType)} width={16} />
 								</div>
-								<div class="mt-1 w-px flex-1 min-h-[16px] bg-white/10"></div>
+								<div class="mt-1 w-px flex-1 min-h-[16px] bg-slate-200 dark:bg-white/10"></div>
 							</div>
 							<div class="min-w-0 flex-1">
-								<p class="m-0 text-[13px] font-semibold text-white">
+								<p class="m-0 text-[13px] font-semibold text-slate-900 dark:text-white">
 									{formatEventType(event.eventType)}
 								</p>
-								<p class="m-0 mt-0.5 flex items-center gap-1 text-[11px] text-cyan-400/80">
+								<p
+									class="m-0 mt-0.5 flex items-center gap-1 text-[11px] text-cyan-600 dark:text-cyan-400/80"
+								>
 									<Icon icon="mdi:clock-outline" width={12} />
 									{formatEventDate(event.occurredAt)}
 								</p>

--- a/src/lib/components/UnitSharePanel.svelte
+++ b/src/lib/components/UnitSharePanel.svelte
@@ -84,58 +84,62 @@
 	}
 </script>
 
-<div class="flex max-h-[70vh] flex-col bg-[#0c1829]">
-	<div class="flex items-center gap-2 border-b border-white/10 px-3 py-2">
+<div class="flex max-h-[70vh] flex-col bg-white dark:bg-[#0c1829]">
+	<div class="flex items-center gap-2 border-b border-slate-200 px-3 py-2 dark:border-white/10">
 		<button
 			type="button"
-			class="flex h-8 w-8 items-center justify-center rounded-lg text-white/60 hover:bg-white/10"
+			class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100 dark:text-white/60 dark:hover:bg-white/10"
 			on:click={onBack}
 			aria-label="Volver"
 		>
 			<Icon icon="mdi:arrow-left" width={20} />
 		</button>
 		<div class="flex-1">
-			<p class="m-0 text-sm font-semibold text-white">Compartir</p>
-			<p class="m-0 text-[11px] text-white/50">{unit?.name || 'Unidad'}</p>
+			<p class="m-0 text-sm font-semibold text-slate-900 dark:text-white">Compartir</p>
+			<p class="m-0 text-[11px] text-slate-500 dark:text-white/50">{unit?.name || 'Unidad'}</p>
 		</div>
 	</div>
 
 	<div class="space-y-0 p-2">
 		<button
 			type="button"
-			class="flex w-full items-center gap-3 rounded-xl px-3 py-3.5 text-left transition-colors hover:bg-white/5"
+			class="flex w-full items-center gap-3 rounded-xl px-3 py-3.5 text-left transition-colors hover:bg-slate-50 dark:hover:bg-white/5"
 			on:click={shareCurrentLocation}
 		>
 			<div class="flex h-10 w-10 items-center justify-center rounded-full bg-cyan-500/15">
-				<Icon icon="mdi:map-marker" width={22} class="text-cyan-400" />
+				<Icon icon="mdi:map-marker" width={22} class="text-cyan-600 dark:text-cyan-400" />
 			</div>
 			<div class="min-w-0 flex-1">
-				<p class="m-0 text-[13px] font-semibold text-white">Compartir ubicación actual</p>
-				<p class="m-0 text-[11px] text-white/45">Envía la posición en tiempo real</p>
+				<p class="m-0 text-[13px] font-semibold text-slate-900 dark:text-white">
+					Compartir ubicación actual
+				</p>
+				<p class="m-0 text-[11px] text-slate-500 dark:text-white/45">
+					Envía la posición en tiempo real
+				</p>
 			</div>
-			<Icon icon="mdi:chevron-right" width={20} class="text-white/25" />
+			<Icon icon="mdi:chevron-right" width={20} class="text-slate-300 dark:text-white/25" />
 		</button>
-		<div class="mx-3 h-px bg-white/[0.07]"></div>
+		<div class="mx-3 h-px bg-slate-100 dark:bg-white/[0.07]"></div>
 
 		<button
 			type="button"
-			class="flex w-full items-center gap-3 rounded-xl px-3 py-3.5 text-left transition-colors hover:bg-white/5"
+			class="flex w-full items-center gap-3 rounded-xl px-3 py-3.5 text-left transition-colors hover:bg-slate-50 dark:hover:bg-white/5"
 			on:click={shareEta}
 		>
 			<div class="flex h-10 w-10 items-center justify-center rounded-full bg-amber-500/15">
 				<Icon icon="mdi:timer-outline" width={22} class="text-amber-400" />
 			</div>
 			<div class="min-w-0 flex-1">
-				<p class="m-0 text-[13px] font-semibold text-white">Compartir ETA</p>
-				<p class="m-0 text-[11px] text-white/45">Tiempo estimado de llegada</p>
+				<p class="m-0 text-[13px] font-semibold text-slate-900 dark:text-white">Compartir ETA</p>
+				<p class="m-0 text-[11px] text-slate-500 dark:text-white/45">Tiempo estimado de llegada</p>
 			</div>
-			<Icon icon="mdi:chevron-right" width={20} class="text-white/25" />
+			<Icon icon="mdi:chevron-right" width={20} class="text-slate-300 dark:text-white/25" />
 		</button>
-		<div class="mx-3 h-px bg-white/[0.07]"></div>
+		<div class="mx-3 h-px bg-slate-100 dark:bg-white/[0.07]"></div>
 
 		<button
 			type="button"
-			class="flex w-full items-center gap-3 rounded-xl px-3 py-3.5 text-left transition-colors hover:bg-white/5 disabled:opacity-50"
+			class="flex w-full items-center gap-3 rounded-xl px-3 py-3.5 text-left transition-colors hover:bg-slate-50 disabled:opacity-50 dark:hover:bg-white/5"
 			on:click={shareTemporaryLink}
 			disabled={loadingLink || !unit?.deviceId}
 		>
@@ -149,8 +153,10 @@
 				{/if}
 			</div>
 			<div class="min-w-0 flex-1">
-				<p class="m-0 text-[13px] font-semibold text-white">Enlace de seguimiento</p>
-				<p class="m-0 text-[11px] text-white/45">
+				<p class="m-0 text-[13px] font-semibold text-slate-900 dark:text-white">
+					Enlace de seguimiento
+				</p>
+				<p class="m-0 text-[11px] text-slate-500 dark:text-white/45">
 					{#if !unit?.deviceId}
 						Requiere dispositivo asignado
 					{:else}
@@ -158,7 +164,7 @@
 					{/if}
 				</p>
 			</div>
-			<Icon icon="mdi:chevron-right" width={20} class="text-white/25" />
+			<Icon icon="mdi:chevron-right" width={20} class="text-slate-300 dark:text-white/25" />
 		</button>
 
 		{#if linkError}
@@ -168,7 +174,7 @@
 			<p class="mx-3 mt-2 text-center text-xs text-emerald-400">Enlace copiado al portapapeles</p>
 		{/if}
 		{#if shareResult?.expires_at}
-			<p class="mx-3 mt-1 text-center text-[10px] text-white/35">
+			<p class="mx-3 mt-1 text-center text-[10px] text-slate-400 dark:text-white/35">
 				Expira: {new Date(shareResult.expires_at).toLocaleString('es-MX')}
 			</p>
 		{/if}

--- a/src/lib/components/UnitsStatusFilterPanels.svelte
+++ b/src/lib/components/UnitsStatusFilterPanels.svelte
@@ -14,7 +14,7 @@
 			id: 'all',
 			label: 'Todas',
 			icon: 'mdi:car-side',
-			iconWrap: 'bg-white/15 text-white',
+			iconWrap: 'bg-slate-200 text-slate-600 dark:bg-white/15 dark:text-white',
 			activeClass:
 				'border-blue-500/50 bg-blue-600 text-white dark:border-blue-500/50 dark:bg-blue-600'
 		},
@@ -22,17 +22,17 @@
 			id: 'moving',
 			label: 'En movimiento',
 			icon: 'mdi:play',
-			iconWrap: 'bg-emerald-500/20 text-emerald-400',
+			iconWrap: 'bg-emerald-500/15 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-400',
 			activeClass:
-				'border-emerald-500/40 bg-emerald-500/15 text-white dark:border-emerald-500/40 dark:bg-emerald-500/15'
+				'border-emerald-500/40 bg-emerald-500/15 text-emerald-800 dark:border-emerald-500/40 dark:bg-emerald-500/15 dark:text-white'
 		},
 		{
 			id: 'stopped',
 			label: 'Paradas',
 			icon: 'mdi:pause',
-			iconWrap: 'bg-orange-500/20 text-orange-400',
+			iconWrap: 'bg-orange-500/15 text-orange-600 dark:bg-orange-500/20 dark:text-orange-400',
 			activeClass:
-				'border-orange-500/40 bg-orange-500/15 text-white dark:border-orange-500/40 dark:bg-orange-500/15'
+				'border-orange-500/40 bg-orange-500/15 text-orange-800 dark:border-orange-500/40 dark:bg-orange-500/15 dark:text-white'
 		}
 	];
 
@@ -43,16 +43,12 @@
 		stopped: units.length - movingCount
 	};
 
-	$: inactiveClass =
-		variant === 'embedded'
-			? 'border-white/10 bg-white/[0.04]'
-			: 'border-slate-200 bg-slate-50 dark:border-white/10 dark:bg-white/[0.04]';
-	$: inactiveLabelClass =
-		variant === 'embedded' ? 'text-white/55' : 'text-slate-600 dark:text-white/55';
-	$: inactiveCountClass = variant === 'embedded' ? 'text-white' : 'text-slate-900 dark:text-white';
+	const inactiveClass = 'border-slate-200 bg-slate-50 dark:border-white/10 dark:bg-white/[0.04]';
+	const inactiveLabelClass = 'text-slate-600 dark:text-white/55';
+	const inactiveCountClass = 'text-slate-900 dark:text-white';
 </script>
 
-<div class="grid grid-cols-3 gap-2">
+<div class="grid grid-cols-3 gap-2" data-variant={variant}>
 	{#each statusPanels as panel (panel.id)}
 		{@const isActive = value === panel.id}
 		<button

--- a/src/lib/components/VehiclePanel.svelte
+++ b/src/lib/components/VehiclePanel.svelte
@@ -1,47 +1,77 @@
 <script>
 	import Icon from '@iconify/svelte';
+	import { onMount } from 'svelte';
 	import CenterSheet from '$lib/components/CenterSheet.svelte';
+	import ColoredVehicleIcon from '$lib/components/Unit/ColoredVehicleIcon.svelte';
 	import { theme } from '$lib/stores/themeStore.js';
 	import {
 		vehicles,
 		selectedVehicles,
 		loadingVehicles,
 		loadingPositions,
-		activeVehicles,
 		selectedVehicleCount,
 		vehicleActions
 	} from '$lib/stores/vehicleStore.js';
-	import { getStatusText, getStatusPillClass } from '$lib/utils/vehicleUtils.js';
+	import {
+		getStatusText,
+		getStatusPillClass,
+		colorSlugToHex,
+		getSpeedColor
+	} from '$lib/utils/vehicleUtils.js';
+	import { unitIcons } from '$lib/data/unitIcons';
 	import { mapService } from '$lib/services/mapService.js';
 
 	export let showVehiclePanel = false;
-	export let showVehicleList = false;
 	export let onTogglePanel = () => {};
 	export let onClose = () => {};
+	/** Cuando true (Sidebar), muestra la lista inline sin FAB ni CenterSheet. */
+	export let embedded = false;
 
-	const listRegionId = 'vehicle-panel-list-region';
+	/** @type {'all' | 'active' | 'inactive'} */
+	let statusFilter = 'all';
+	let searchQuery = '';
 
 	$: isLightTheme = $theme === 'light';
 
-	async function toggleVehicleList() {
-		showVehicleList = !showVehicleList;
+	$: activeCount = $vehicles.filter((v) => v.status === 'active').length;
+	$: inactiveCount = $vehicles.filter((v) => v.status !== 'active').length;
 
-		// Si se está abriendo la lista y no hay vehículos cargados, cargarlos
-		if (showVehicleList && $vehicles.length === 0) {
+	$: filteredVehicles = $vehicles.filter((v) => {
+		const q = searchQuery.trim().toLowerCase();
+		const matchesSearch =
+			!q ||
+			v.name?.toLowerCase().includes(q) ||
+			v.driver?.toLowerCase().includes(q) ||
+			v.model?.toLowerCase().includes(q) ||
+			v.brand?.toLowerCase().includes(q) ||
+			v.plate?.toLowerCase().includes(q);
+		const matchesStatus =
+			statusFilter === 'all' ||
+			(statusFilter === 'active' ? v.status === 'active' : v.status !== 'active');
+		return matchesSearch && matchesStatus;
+	});
+
+	$: allFilteredSelected =
+		filteredVehicles.length > 0 && filteredVehicles.every((v) => $selectedVehicles.includes(v.id));
+
+	onMount(async () => {
+		if ($vehicles.length === 0) {
 			await vehicleActions.loadVehicles();
 		}
-	}
+	});
 
 	function toggleVehicleSelection(vehicleId) {
 		vehicleActions.toggleVehicleSelection(vehicleId);
 	}
 
-	function selectAllVehicles() {
-		vehicleActions.selectAllVehicles();
-	}
-
-	function clearVehicleSelection() {
-		vehicleActions.clearSelection();
+	function toggleSelectAllFiltered() {
+		if (allFilteredSelected) {
+			const ids = new Set(filteredVehicles.map((v) => v.id));
+			selectedVehicles.update((curr) => curr.filter((id) => !ids.has(id)));
+		} else {
+			const ids = filteredVehicles.map((v) => v.id);
+			selectedVehicles.update((curr) => [...new Set([...curr, ...ids])]);
+		}
 	}
 
 	async function refreshPositions() {
@@ -53,7 +83,6 @@
 		const vehiclesWithCoords = selectedVehiclesList.filter(
 			(v) => (v.latitude || v.lat) && (v.longitude || v.lng)
 		);
-
 		if (vehiclesWithCoords.length > 0) {
 			mapService.centerOnVehicles(vehiclesWithCoords);
 		}
@@ -71,252 +100,377 @@
 		if (lat == null || lng == null) return null;
 		return { lat, lng };
 	}
+
+	function unitIconSrc(v) {
+		const iconType = v.icon_type || v.iconType || 'vehicle-car-sedan';
+		return unitIcons[iconType] || unitIcons['vehicle-car-sedan'];
+	}
+
+	function unitColorHex(v) {
+		return colorSlugToHex(v.color) || v.profile_color_hex || '#94a3b8';
+	}
+
+	function unitTypeLabel(v) {
+		const fromProfile = [v.brand, v.model].filter(Boolean).join(' ');
+		if (fromProfile) return fromProfile;
+		const t = v.icon_type || v.iconType || '';
+		const labels = {
+			'vehicle-car-sedan': 'Auto sedan',
+			'vehicle-car-truck': 'Camioneta',
+			'vehicle-backhoe-loader': 'Retroexcavadora',
+			'vehicle-motorbike-sport': 'Motocicleta',
+			'vehicle-trailer-dryvan': 'Remolque'
+		};
+		return labels[t] || 'Unidad';
+	}
+
+	function ignitionLabel(v) {
+		return String(v?.engineStatus ?? '').toUpperCase() === 'ON' ? 'Encendida' : 'Apagada';
+	}
+
+	function ignitionOn(v) {
+		return String(v?.engineStatus ?? '').toUpperCase() === 'ON';
+	}
+
+	function formatSpeed(v) {
+		const spd = Number(v?.speed);
+		if (Number.isNaN(spd)) return '—';
+		return `${spd.toFixed(2)} km/h`;
+	}
+
+	function formatVoltage(val) {
+		const n = Number(val);
+		if (val == null || Number.isNaN(n)) return '—';
+		return `${n.toFixed(1)}`;
+	}
+
+	function formatSignal(v) {
+		const n = Number(v?.rxLvl);
+		if (v?.rxLvl == null || Number.isNaN(n)) return '—';
+		return `${n} dBm`;
+	}
 </script>
 
-<button
-	type="button"
-	on:click={onTogglePanel}
-	aria-label="Abrir panel de control de vehículos"
-	aria-haspopup="dialog"
-	aria-expanded={showVehiclePanel}
-	class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full text-white shadow-lg transition-all duration-200 hover:scale-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400 focus-visible:ring-offset-transparent {isLightTheme
-		? 'border border-slate-600/45 bg-gradient-to-br from-slate-700 to-slate-900 shadow-[0_2px_6px_rgb(15_23_42_/_0.2)] [box-shadow:inset_0_1px_0_rgb(255_255_255_/_0.08)] hover:brightness-[1.07]'
-		: 'border border-white/10 bg-white/10 hover:bg-white/[0.16]'}"
-	class:ring-2={showVehiclePanel}
-	class:ring-emerald-400={showVehiclePanel}
-	class:ring-offset-2={showVehiclePanel}
-	class:ring-offset-slate-900={showVehiclePanel && isLightTheme}
-	class:ring-offset-slate-950={showVehiclePanel && !isLightTheme}
->
-	<Icon icon="mdi:car-side" class="h-8 w-8 shrink-0" aria-hidden="true" />
-</button>
+{#if !embedded}
+	<button
+		type="button"
+		on:click={onTogglePanel}
+		aria-label="Abrir panel de control de vehículos"
+		aria-haspopup="dialog"
+		aria-expanded={showVehiclePanel}
+		class="flex h-12 w-12 shrink-0 items-center justify-center rounded-full text-white shadow-lg transition-all duration-200 hover:scale-110 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400 focus-visible:ring-offset-transparent {isLightTheme
+			? 'border border-slate-600/45 bg-gradient-to-br from-slate-700 to-slate-900 shadow-[0_2px_6px_rgb(15_23_42_/_0.2)] [box-shadow:inset_0_1px_0_rgb(255_255_255_/_0.08)] hover:brightness-[1.07]'
+			: 'border border-white/10 bg-white/10 hover:bg-white/[0.16]'}"
+		class:ring-2={showVehiclePanel}
+		class:ring-emerald-400={showVehiclePanel}
+		class:ring-offset-2={showVehiclePanel}
+		class:ring-offset-slate-900={showVehiclePanel && isLightTheme}
+		class:ring-offset-slate-950={showVehiclePanel && !isLightTheme}
+	>
+		<Icon icon="mdi:car-side" class="h-8 w-8 shrink-0" aria-hidden="true" />
+	</button>
+{/if}
 
-<CenterSheet open={showVehiclePanel} title="Vehículos" onClose={() => onClose()}>
-	<div class="space-y-5">
-		<section class="space-y-3" aria-labelledby="vehicle-panel-actions-heading">
-			<h3 id="vehicle-panel-actions-heading" class="sr-only">Acciones del panel de vehículos</h3>
-			<button
-				type="button"
-				class="flex w-full items-center justify-center gap-2 rounded-xl border border-emerald-600/20 bg-emerald-600 px-4 py-3 text-sm font-semibold text-white shadow-md shadow-emerald-900/20 transition-colors hover:bg-emerald-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500 dark:border-emerald-500/30 dark:shadow-emerald-950/40"
-				on:click={toggleVehicleList}
-				aria-expanded={showVehicleList}
-				aria-controls={listRegionId}
-			>
-				<Icon icon="mdi:view-list-outline" class="h-5 w-5 shrink-0" aria-hidden="true" />
-				{showVehicleList ? 'Ocultar lista de vehículos' : 'Ver lista de vehículos'}
-			</button>
+{#snippet vehicleListBody()}
+	<div class="flex min-h-0 flex-1 flex-col gap-3">
+		<div>
+			<p class="m-0 text-[13px] text-slate-500 dark:text-slate-400">
+				Visualiza y administra tus unidades en tiempo real
+			</p>
+		</div>
 
-			{#if showVehicleList}
-				<div
-					id={listRegionId}
-					role="region"
-					aria-label="Lista y selección de vehículos"
-					class="max-h-64 overflow-y-auto overscroll-contain rounded-xl border border-slate-200 bg-slate-50 p-3 dark:border-slate-600 dark:bg-slate-800/80"
+		<!-- Búsqueda -->
+		<div
+			class="flex items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2.5 dark:border-white/10 dark:bg-white/[0.06]"
+		>
+			<Icon icon="mdi:magnify" width={16} class="shrink-0 text-slate-400 dark:text-white/40" />
+			<input
+				type="search"
+				bind:value={searchQuery}
+				placeholder="Buscar unidad, conductor..."
+				class="min-w-0 flex-1 border-0 bg-transparent text-[14px] text-slate-900 outline-none placeholder:text-slate-400 dark:text-white dark:placeholder:text-white/35"
+			/>
+			{#if searchQuery}
+				<button
+					type="button"
+					class="text-slate-400 dark:text-white/40"
+					on:click={() => (searchQuery = '')}
+					aria-label="Limpiar búsqueda"
 				>
-					<div class="mb-3 flex flex-wrap items-center justify-between gap-2">
-						<h4 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Selección</h4>
-						<div
-							class="flex flex-wrap gap-2"
-							role="group"
-							aria-label="Acciones de selección masiva"
-						>
-							<button
-								type="button"
-								class="rounded-lg border border-blue-600/30 bg-blue-600 px-2.5 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
-								on:click={selectAllVehicles}
-							>
-								Seleccionar todos
-							</button>
-							<button
-								type="button"
-								class="rounded-lg border border-slate-400/40 bg-slate-600 px-2.5 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-slate-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400 dark:border-slate-500 dark:bg-slate-700 dark:hover:bg-slate-600"
-								on:click={clearVehicleSelection}
-							>
-								Limpiar selección
-							</button>
-						</div>
-					</div>
-
-					{#if $loadingVehicles || $loadingPositions}
-						<div
-							class="flex items-center justify-center gap-2 py-6"
-							role="status"
-							aria-live="polite"
-							aria-busy="true"
-						>
-							<div
-								class="h-6 w-6 shrink-0 animate-spin rounded-full border-2 border-slate-200 border-b-blue-600 dark:border-slate-600 dark:border-b-blue-400"
-								aria-hidden="true"
-							></div>
-							<span class="text-sm text-slate-600 dark:text-slate-300">
-								{$loadingVehicles ? 'Cargando vehículos…' : 'Actualizando posiciones…'}
-							</span>
-						</div>
-					{:else if $vehicles.length > 0}
-						<ul class="list-none space-y-1 p-0">
-							{#each $vehicles as vehicle (vehicle.id)}
-								{@const coords = vehicleCoords(vehicle)}
-								<li
-									class="rounded-lg border border-transparent p-2 transition-colors hover:border-slate-200/80 hover:bg-white/90 dark:hover:border-slate-600/60 dark:hover:bg-slate-700/50"
-								>
-									<div class="flex items-start gap-3">
-										<input
-											id="vehicle-select-{vehicle.id}"
-											type="checkbox"
-											checked={$selectedVehicles.includes(vehicle.id)}
-											class="mt-1 size-4 shrink-0 rounded border-slate-300 text-blue-600 focus:ring-2 focus:ring-blue-500 focus:ring-offset-0 dark:border-slate-500 dark:bg-slate-900 dark:text-blue-500"
-											aria-label="Incluir {vehicle.name} en la selección del mapa"
-											aria-describedby="vehicle-meta-{vehicle.id}"
-											on:change={() => toggleVehicleSelection(vehicle.id)}
-										/>
-										<div class="min-w-0 flex-1" id="vehicle-meta-{vehicle.id}">
-											<div class="flex items-start justify-between gap-2">
-												<button
-													type="button"
-													class="truncate text-left text-sm font-semibold text-slate-900 underline-offset-2 hover:text-blue-600 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 disabled:no-underline dark:text-slate-100 dark:hover:text-blue-400"
-													on:click={() => centerOnVehicle(vehicle)}
-													disabled={!coords}
-													aria-label="Centrar el mapa en {vehicle.name}"
-												>
-													{vehicle.name}
-												</button>
-												<span
-													class="inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-semibold {getStatusPillClass(
-														vehicle.status
-													)}"
-												>
-													{getStatusText(vehicle.status)}
-												</span>
-											</div>
-											<dl class="mt-1 space-y-0.5 text-xs text-slate-600 dark:text-slate-400">
-												<div class="flex flex-wrap gap-x-1">
-													<dt class="font-medium text-slate-500 dark:text-slate-500">Conductor</dt>
-													<dd>{vehicle.driver || 'Sin conductor'}</dd>
-												</div>
-												<div class="flex flex-wrap gap-x-1">
-													<dt class="font-medium text-slate-500 dark:text-slate-500">Ubicación</dt>
-													<dd>{vehicle.location || 'Desconocida'}</dd>
-												</div>
-												{#if vehicle.deviceId}
-													<div class="flex flex-wrap gap-x-1">
-														<dt class="font-medium text-slate-500 dark:text-slate-500">
-															Dispositivo
-														</dt>
-														<dd class="font-mono text-[0.6875rem]">{vehicle.deviceId}</dd>
-													</div>
-												{/if}
-												{#if coords}
-													<div class="flex flex-wrap gap-x-1">
-														<dt class="font-medium text-slate-500 dark:text-slate-500">
-															Coordenadas
-														</dt>
-														<dd class="font-mono text-[0.6875rem]">
-															{coords.lat.toFixed(4)}, {coords.lng.toFixed(4)}
-														</dd>
-													</div>
-												{/if}
-												{#if vehicle.speed !== undefined}
-													<div class="flex flex-wrap gap-x-1">
-														<dt class="font-medium text-slate-500 dark:text-slate-500">
-															Movimiento
-														</dt>
-														<dd>
-															{vehicle.speed} km/h · Batería {vehicle.battery ?? 0}%
-														</dd>
-													</div>
-												{/if}
-												{#if vehicle.lastUpdateFormatted}
-													<div class="flex flex-wrap gap-x-1">
-														<dt class="font-medium text-slate-500 dark:text-slate-500">
-															Última actualización
-														</dt>
-														<dd>{vehicle.lastUpdateFormatted}</dd>
-													</div>
-												{/if}
-											</dl>
-										</div>
-									</div>
-								</li>
-							{/each}
-						</ul>
-
-						{#if $selectedVehicleCount > 0}
-							<div
-								class="mt-3 border-t border-slate-200 pt-3 dark:border-slate-600"
-								role="status"
-								aria-live="polite"
-							>
-								<p class="mb-2 text-xs font-medium text-slate-600 dark:text-slate-300">
-									{$selectedVehicleCount} unidad{$selectedVehicleCount !== 1 ? 'es' : ''} seleccionada{$selectedVehicleCount !==
-									1
-										? 's'
-										: ''}
-								</p>
-								<button
-									type="button"
-									class="w-full rounded-lg border border-emerald-600/25 bg-emerald-600 px-3 py-2.5 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-emerald-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500"
-									on:click={trackSelectedVehicles}
-								>
-									Rastrear seleccionados en el mapa
-								</button>
-							</div>
-						{/if}
-					{:else}
-						<p class="py-6 text-center text-sm text-slate-500 dark:text-slate-400" role="status">
-							No hay vehículos disponibles
-						</p>
-					{/if}
-				</div>
+					<Icon icon="mdi:close-circle" width={16} />
+				</button>
 			{/if}
+		</div>
 
+		<!-- Filtros de estado (datos reales: activa / inactiva) -->
+		<div class="flex flex-wrap gap-2" role="group" aria-label="Filtrar por estado">
 			<button
 				type="button"
-				class="flex w-full items-center justify-center gap-2 rounded-xl border border-blue-600/25 bg-blue-600 px-4 py-3 text-sm font-semibold text-white shadow-md shadow-blue-900/25 transition-colors hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:pointer-events-none disabled:opacity-60 dark:border-blue-500/30 dark:shadow-blue-950/40"
+				class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[12px] font-semibold transition-colors {statusFilter ===
+				'all'
+					? 'border-slate-700 bg-slate-800 text-white dark:border-slate-300 dark:bg-slate-200 dark:text-slate-900'
+					: 'border-slate-200 bg-white text-slate-600 hover:bg-slate-50 dark:border-white/10 dark:bg-white/[0.04] dark:text-slate-300'}"
+				on:click={() => (statusFilter = 'all')}
+				aria-pressed={statusFilter === 'all'}
+			>
+				Todas · {$vehicles.length}
+			</button>
+			<button
+				type="button"
+				class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[12px] font-semibold transition-colors {statusFilter ===
+				'active'
+					? 'border-emerald-600/40 bg-emerald-500/15 text-emerald-800 dark:border-emerald-400/40 dark:text-emerald-200'
+					: 'border-slate-200 bg-white text-slate-600 hover:bg-slate-50 dark:border-white/10 dark:bg-white/[0.04] dark:text-slate-300'}"
+				on:click={() => (statusFilter = 'active')}
+				aria-pressed={statusFilter === 'active'}
+			>
+				<span class="h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden="true"></span>
+				{activeCount} Activas
+			</button>
+			<button
+				type="button"
+				class="inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[12px] font-semibold transition-colors {statusFilter ===
+				'inactive'
+					? 'border-red-600/40 bg-red-500/15 text-red-800 dark:border-red-400/40 dark:text-red-200'
+					: 'border-slate-200 bg-white text-slate-600 hover:bg-slate-50 dark:border-white/10 dark:bg-white/[0.04] dark:text-slate-300'}"
+				on:click={() => (statusFilter = 'inactive')}
+				aria-pressed={statusFilter === 'inactive'}
+			>
+				<span class="h-1.5 w-1.5 rounded-full bg-red-500" aria-hidden="true"></span>
+				{inactiveCount} Inactivas
+			</button>
+		</div>
+
+		<!-- Cabecera selección -->
+		<div class="flex items-center justify-between gap-2">
+			<label
+				class="flex cursor-pointer items-center gap-2 text-[12px] font-medium text-slate-600 dark:text-slate-300"
+			>
+				<input
+					type="checkbox"
+					class="size-3.5 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500 dark:border-slate-500"
+					checked={allFilteredSelected}
+					disabled={filteredVehicles.length === 0}
+					on:change={toggleSelectAllFiltered}
+				/>
+				Seleccionar todas ({filteredVehicles.length})
+			</label>
+			<button
+				type="button"
+				class="inline-flex items-center gap-1 rounded-lg px-2 py-1 text-[11px] font-semibold text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 disabled:opacity-50 dark:text-slate-400 dark:hover:bg-white/10 dark:hover:text-white"
 				on:click={refreshPositions}
 				disabled={$loadingPositions}
 				aria-busy={$loadingPositions}
 			>
 				<Icon
 					icon="mdi:refresh"
-					class="h-5 w-5 shrink-0 {$loadingPositions ? 'animate-spin' : ''}"
+					class="h-3.5 w-3.5 {$loadingPositions ? 'animate-spin' : ''}"
 					aria-hidden="true"
 				/>
-				Actualizar posiciones
+				Actualizar
 			</button>
-		</section>
+		</div>
 
-		<section
-			class="rounded-xl border border-slate-200 bg-slate-50/80 p-3 dark:border-slate-600 dark:bg-slate-800/50"
-			aria-labelledby="vehicle-panel-status-heading"
-		>
-			<h3
-				id="vehicle-panel-status-heading"
-				class="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
-			>
-				Estado del sistema
-			</h3>
-			<ul class="list-none space-y-2 p-0 text-xs text-slate-700 dark:text-slate-200">
-				<li class="flex items-center gap-2">
-					<span
-						class="h-2 w-2 shrink-0 animate-pulse rounded-full bg-emerald-500"
+		<!-- Lista de cards -->
+		<div class="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+			{#if $loadingVehicles || ($loadingPositions && $vehicles.length === 0)}
+				<div
+					class="flex items-center justify-center gap-2 py-10"
+					role="status"
+					aria-live="polite"
+					aria-busy="true"
+				>
+					<div
+						class="h-6 w-6 shrink-0 animate-spin rounded-full border-2 border-slate-200 border-b-emerald-600 dark:border-slate-600 dark:border-b-emerald-400"
 						aria-hidden="true"
-					></span>
-					<span
-						>Conectado · {$activeVehicles.length} unidad{$activeVehicles.length !== 1 ? 'es' : ''} activa{$activeVehicles.length !==
-						1
-							? 's'
-							: ''}</span
-					>
-				</li>
-				{#if $selectedVehicleCount > 0}
-					<li class="flex items-center gap-2">
-						<span class="h-2 w-2 shrink-0 rounded-full bg-blue-500" aria-hidden="true"></span>
-						<span>
-							{$selectedVehicleCount} en selección para seguimiento
-						</span>
-					</li>
-				{/if}
-			</ul>
-		</section>
+					></div>
+					<span class="text-sm text-slate-600 dark:text-slate-300">Cargando unidades…</span>
+				</div>
+			{:else if filteredVehicles.length === 0}
+				<p class="py-10 text-center text-sm text-slate-500 dark:text-slate-400" role="status">
+					{searchQuery || statusFilter !== 'all'
+						? 'Sin resultados'
+						: 'No hay vehículos disponibles'}
+				</p>
+			{:else}
+				<ul class="m-0 flex list-none flex-col gap-2.5 p-0" aria-label="Lista de unidades">
+					{#each filteredVehicles as vehicle (vehicle.id)}
+						{@const coords = vehicleCoords(vehicle)}
+						{@const isChecked = $selectedVehicles.includes(vehicle.id)}
+						<li
+							class="rounded-xl border border-slate-200 bg-white p-3 shadow-sm transition-colors dark:border-white/10 dark:bg-white/[0.04]"
+						>
+							<div class="flex items-start gap-2.5">
+								<input
+									id="vehicle-select-{vehicle.id}"
+									type="checkbox"
+									checked={isChecked}
+									class="mt-1 size-3.5 shrink-0 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500 dark:border-slate-500"
+									aria-label="Incluir {vehicle.name} en la selección"
+									on:change={() => toggleVehicleSelection(vehicle.id)}
+								/>
+
+								<div class="flex h-9 w-9 shrink-0 items-center justify-center">
+									<ColoredVehicleIcon
+										src={unitIconSrc(vehicle)}
+										colorHex={unitColorHex(vehicle)}
+										sizeClass="h-8 w-8"
+										alt=""
+									/>
+								</div>
+
+								<div class="min-w-0 flex-1">
+									<div class="flex items-start justify-between gap-2">
+										<div class="min-w-0">
+											<p class="m-0 truncate text-[14px] font-bold text-slate-900 dark:text-white">
+												{vehicle.name}
+											</p>
+										</div>
+										<span
+											class="inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-semibold {getStatusPillClass(
+												vehicle.status
+											)}"
+										>
+											{vehicle.status === 'active'
+												? 'Activa'
+												: vehicle.status === 'inactive'
+													? 'Inactiva'
+													: getStatusText(vehicle.status)}
+										</span>
+									</div>
+
+									<div
+										class="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-slate-500 dark:text-slate-400"
+									>
+										<span class="inline-flex items-center gap-1">
+											<Icon
+												icon="mdi:account-outline"
+												class="h-3.5 w-3.5 shrink-0"
+												aria-hidden="true"
+											/>
+											{vehicle.driver || 'Sin conductor'}
+										</span>
+										<span class="inline-flex items-center gap-1">
+											<Icon
+												icon="mdi:map-marker-outline"
+												class="h-3.5 w-3.5 shrink-0"
+												aria-hidden="true"
+											/>
+											{unitTypeLabel(vehicle)}
+										</span>
+									</div>
+
+									<div
+										class="mt-2 grid grid-cols-3 gap-2 border-t border-slate-100 pt-2 dark:border-white/[0.06]"
+									>
+										<div>
+											<p class="m-0 text-[10px] font-medium uppercase tracking-wide text-slate-400">
+												Ignición
+											</p>
+											<p
+												class="m-0 mt-0.5 inline-flex items-center gap-1 text-[12px] font-semibold text-slate-800 dark:text-slate-100"
+											>
+												<span
+													class="h-1.5 w-1.5 rounded-full {ignitionOn(vehicle)
+														? 'bg-emerald-500'
+														: 'bg-slate-400'}"
+													aria-hidden="true"
+												></span>
+												{ignitionLabel(vehicle)}
+											</p>
+										</div>
+										<div>
+											<p class="m-0 text-[10px] font-medium uppercase tracking-wide text-slate-400">
+												Velocidad
+											</p>
+											<p
+												class="m-0 mt-0.5 text-[12px] font-bold {getSpeedColor(
+													Number(vehicle.speed) || 0
+												)}"
+											>
+												{formatSpeed(vehicle)}
+											</p>
+										</div>
+										<div>
+											<p class="m-0 text-[10px] font-medium uppercase tracking-wide text-slate-400">
+												Actualización
+											</p>
+											<p
+												class="m-0 mt-0.5 truncate text-[11px] font-medium text-slate-700 dark:text-slate-200"
+											>
+												{vehicle.lastUpdateFormatted || '—'}
+											</p>
+										</div>
+									</div>
+
+									<div
+										class="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-slate-500 dark:text-slate-400"
+									>
+										<span>
+											<span class="font-semibold text-slate-700 dark:text-slate-200"
+												>{formatVoltage(vehicle.mainBatteryVoltage)}</span
+											>
+											Vext
+										</span>
+										<span>
+											<span class="font-semibold text-slate-700 dark:text-slate-200"
+												>{formatVoltage(vehicle.backupBatteryVoltage)}</span
+											>
+											Vint
+										</span>
+										<span class="inline-flex items-center gap-1">
+											<Icon icon="mdi:signal" class="h-3.5 w-3.5" aria-hidden="true" />
+											<span class="font-semibold text-slate-700 dark:text-slate-200"
+												>{formatSignal(vehicle)}</span
+											>
+											Señal
+										</span>
+									</div>
+								</div>
+
+								<button
+									type="button"
+									class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-emerald-600 text-white shadow-sm transition-colors hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-40"
+									on:click={() => centerOnVehicle(vehicle)}
+									disabled={!coords}
+									aria-label="Centrar el mapa en {vehicle.name}"
+									title="Centrar en mapa"
+								>
+									<Icon icon="mdi:crosshairs-gps" class="h-4 w-4" aria-hidden="true" />
+								</button>
+							</div>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</div>
+
+		<!-- Pie: conteo + acciones selección -->
+		<div class="flex shrink-0 flex-col gap-2 border-t border-slate-200 pt-3 dark:border-white/10">
+			<p class="m-0 text-[11px] text-slate-500 dark:text-slate-400">
+				Mostrando {filteredVehicles.length === 0 ? 0 : 1} a {filteredVehicles.length} de
+				{$vehicles.length} unidades
+			</p>
+			{#if $selectedVehicleCount > 0}
+				<button
+					type="button"
+					class="w-full rounded-lg border border-emerald-600/25 bg-emerald-600 px-3 py-2.5 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-emerald-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500"
+					on:click={trackSelectedVehicles}
+				>
+					Rastrear seleccionados ({$selectedVehicleCount})
+				</button>
+			{/if}
+		</div>
 	</div>
-</CenterSheet>
+{/snippet}
+
+{#if embedded}
+	<div class="flex h-full min-h-0 flex-col">
+		<h2 class="m-0 mb-1 text-lg font-bold text-slate-900 dark:text-white">Seguimiento</h2>
+		{@render vehicleListBody()}
+	</div>
+{:else}
+	<CenterSheet open={showVehiclePanel} title="Seguimiento" onClose={() => onClose()}>
+		{@render vehicleListBody()}
+	</CenterSheet>
+{/if}

--- a/src/lib/components/reports/ReportsUnitPicker.svelte
+++ b/src/lib/components/reports/ReportsUnitPicker.svelte
@@ -19,13 +19,13 @@
 
 {#if open}
 	<div
-		class="fixed inset-0 z-[110] flex items-end justify-center bg-black/50 sm:items-center sm:p-4"
+		class="fixed inset-0 z-[110] flex items-end justify-center bg-black/40 sm:items-center sm:p-4 dark:bg-black/50"
 		role="presentation"
 		on:click|self={onClose}
 		on:keydown={(e) => e.key === 'Escape' && onClose()}
 	>
 		<div
-			class="flex w-full max-w-md flex-col overflow-hidden rounded-t-2xl border border-white/10 bg-[#0c1829] shadow-2xl sm:rounded-2xl"
+			class="flex w-full max-w-md flex-col overflow-hidden rounded-t-2xl border border-slate-200 bg-white shadow-2xl dark:border-white/10 dark:bg-[#0c1829] sm:rounded-2xl"
 			style="max-height: min(70vh, 480px); margin-bottom: calc(56px + env(safe-area-inset-bottom, 0px));"
 			role="dialog"
 			aria-modal="true"
@@ -33,15 +33,24 @@
 			transition:fly={{ y: 24, duration: 200 }}
 		>
 			<!-- Header -->
-			<div class="shrink-0 border-b border-white/10 px-4 py-3">
+			<div class="shrink-0 border-b border-slate-200 px-4 py-3 dark:border-white/10">
 				<div class="mb-2.5 flex items-center justify-between">
 					<div>
-						<h2 id="unit-picker-title" class="m-0 text-[15px] font-bold text-white">Unidades</h2>
-						<p class="m-0 text-[11px] text-white/40">
+						<h2
+							id="unit-picker-title"
+							class="m-0 text-[15px] font-bold text-slate-900 dark:text-white"
+						>
+							Unidades
+						</h2>
+						<p class="m-0 text-[11px] text-slate-500 dark:text-white/40">
 							{selectedIds.size}/3 seleccionada{selectedIds.size !== 1 ? 's' : ''}
 						</p>
 					</div>
-					<button type="button" class="text-[14px] font-semibold text-cyan-400" on:click={onClose}>
+					<button
+						type="button"
+						class="text-[14px] font-semibold text-cyan-700 dark:text-cyan-400"
+						on:click={onClose}
+					>
 						Listo
 					</button>
 				</div>
@@ -49,14 +58,14 @@
 					<Icon
 						icon="mdi:magnify"
 						width={16}
-						class="absolute left-3 top-1/2 -translate-y-1/2 text-white/35"
+						class="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 dark:text-white/35"
 						aria-hidden="true"
 					/>
 					<input
 						type="search"
 						bind:value={searchQuery}
 						placeholder="Buscar unidad…"
-						class="h-9 w-full rounded-xl border border-white/10 bg-white/[0.06] pl-8 pr-3 text-[13px] text-white placeholder:text-white/30 outline-none focus:border-cyan-500/50"
+						class="h-9 w-full rounded-xl border border-slate-200 bg-slate-50 pl-8 pr-3 text-[13px] text-slate-900 placeholder:text-slate-400 outline-none focus:border-cyan-500/50 dark:border-white/10 dark:bg-white/[0.06] dark:text-white dark:placeholder:text-white/30"
 					/>
 				</div>
 			</div>
@@ -64,7 +73,7 @@
 			<!-- Lista -->
 			<ul class="m-0 min-h-0 flex-1 list-none overflow-y-auto overscroll-contain p-2">
 				{#if filtered.length === 0}
-					<li class="py-6 text-center text-sm text-white/40">
+					<li class="py-6 text-center text-sm text-slate-400 dark:text-white/40">
 						{searchQuery ? 'Sin resultados' : 'No hay unidades disponibles'}
 					</li>
 				{:else}
@@ -75,7 +84,7 @@
 							<button
 								type="button"
 								class="mb-0.5 flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors last:mb-0
-									{selected ? 'bg-cyan-500/15' : 'hover:bg-white/[0.05]'}
+									{selected ? 'bg-cyan-500/15 dark:bg-cyan-500/15' : 'hover:bg-slate-100 dark:hover:bg-white/[0.05]'}
 									{atLimit ? 'cursor-not-allowed opacity-35' : ''}"
 								disabled={atLimit}
 								on:click={() => onToggle(u.id)}
@@ -83,20 +92,26 @@
 							>
 								<div
 									class="flex h-5 w-5 shrink-0 items-center justify-center rounded border transition-colors {selected
-										? 'border-cyan-400 bg-cyan-500'
-										: 'border-white/20 bg-white/[0.04]'}"
+										? 'border-cyan-500 bg-cyan-500 dark:border-cyan-400'
+										: 'border-slate-300 bg-white dark:border-white/20 dark:bg-white/[0.04]'}"
 									aria-hidden="true"
 								>
 									{#if selected}<Icon icon="mdi:check" width={13} class="text-white" />{/if}
 								</div>
 								<div class="min-w-0 flex-1">
-									<p class="m-0 truncate text-[13px] font-semibold text-white">{u.name}</p>
+									<p class="m-0 truncate text-[13px] font-semibold text-slate-900 dark:text-white">
+										{u.name}
+									</p>
 									{#if !u.deviceId}
-										<p class="m-0 text-[10px] text-amber-400/70">Sin dispositivo</p>
+										<p class="m-0 text-[10px] text-amber-600 dark:text-amber-400/70">
+											Sin dispositivo
+										</p>
 									{/if}
 								</div>
 								{#if selected}
-									<span class="shrink-0 text-[11px] font-semibold text-cyan-400">✓</span>
+									<span class="shrink-0 text-[11px] font-semibold text-cyan-700 dark:text-cyan-400"
+										>✓</span
+									>
 								{/if}
 							</button>
 						</li>
@@ -105,8 +120,8 @@
 			</ul>
 
 			<!-- Footer -->
-			<div class="shrink-0 border-t border-white/[0.07] px-4 py-2.5">
-				<p class="m-0 text-center text-[11px] text-white/30">
+			<div class="shrink-0 border-t border-slate-200 px-4 py-2.5 dark:border-white/[0.07]">
+				<p class="m-0 text-center text-[11px] text-slate-500 dark:text-white/30">
 					{#if selectedIds.size >= 3}
 						Límite alcanzado · deselecciona una para cambiar
 					{:else}

--- a/src/lib/services/mapService.js
+++ b/src/lib/services/mapService.js
@@ -1,10 +1,11 @@
-import { writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import * as GoogleMapsLoader from '@googlemaps/js-api-loader';
 import {
 	MarkerClusterer,
 	SuperClusterAlgorithm
 } from '@googlemaps/markerclusterer/dist/index.esm.mjs';
 import { darkBlueCarStyle, DBLUE, grayBlueMapStyle, COLORS } from '$lib/mapStyles';
+import { theme } from '$lib/stores/themeStore.js';
 import {
 	buildVehicleMarkerDataUrl,
 	getStatusHexColor,
@@ -15,6 +16,8 @@ import {
 
 /** Color del rastro en vivo y del indicador de seguimiento. */
 const LIVE_TRAIL_COLOR = '#00a6c0';
+/** Breakpoint móvil (alineado con MapContainer / Tailwind `sm`). */
+const MOBILE_MQ = '(max-width: 639px)';
 /** Últimos N puntos por unidad (~5 min a 1 update/5s). */
 const MAX_TRAIL_POINTS = 60;
 const TRAIL_FADE_MS = 220;
@@ -234,9 +237,9 @@ class MapService {
 
 			this.google = await loader.load();
 
-			const isMobileLayout =
-				typeof window !== 'undefined' && window.matchMedia('(max-width: 639px)').matches;
+			const isMobileLayout = this._isMobileLayout();
 
+			const initialTheme = this._resolveInitialMapTheme();
 			const mapOptions = {
 				center: { lat: 19.4326, lng: -99.1332 },
 				zoom: 10,
@@ -251,8 +254,8 @@ class MapService {
 				streetViewControl: false,
 				rotateControl: false,
 				scaleControl: false,
-				styles: darkBlueCarStyle,
-				backgroundColor: DBLUE.bg
+				styles: initialTheme === 'light' ? grayBlueMapStyle : darkBlueCarStyle,
+				backgroundColor: initialTheme === 'light' ? COLORS.grayLight : DBLUE.bg
 			};
 
 			this.map = new this.google.maps.Map(mapElement, mapOptions);
@@ -715,10 +718,7 @@ class MapService {
 				}
 			}
 		} else {
-			const m = this.addVehicleMarker(vehicle);
-			if (m && this.vehicleClusterer) {
-				this.vehicleClusterer.addMarker(m);
-			}
+			// No recrear marcador aquí: la visibilidad la controla mapVisibleUnitIds vía MapContainer.
 		}
 	}
 
@@ -993,8 +993,14 @@ class MapService {
 		}
 	}
 
+	/** @returns {boolean} */
+	_isMobileLayout() {
+		return typeof window !== 'undefined' && window.matchMedia(MOBILE_MQ).matches;
+	}
+
 	/**
 	 * Abre el InfoWindow de la unidad (mismo contenido que al pulsar el marcador).
+	 * En móvil no se muestra: el panel inferior ya cubre la ficha de la unidad.
 	 * Si el marcador está en un cluster, se ancla por la posición del `Marker`.
 	 * @param {{ id: string }} vehicle
 	 * @param {{ refreshContent?: boolean }} [opts]
@@ -1002,6 +1008,12 @@ class MapService {
 	openVehicleInfoWindow(vehicle, opts = {}) {
 		const refreshContent = opts.refreshContent !== false;
 		if (!this.map || !this.google || !vehicle?.id) return;
+
+		// Móvil: sheet de tracking; evita duplicar la ficha sobre el mapa.
+		if (this._isMobileLayout()) {
+			this.closeAllVehicleInfoWindows();
+			return;
+		}
 
 		const entry = this.markers.get(vehicle.id);
 		if (!entry?.infoWindow || !entry.marker) return;
@@ -1089,6 +1101,25 @@ class MapService {
 	}
 
 	/**
+	 * Tema del mapa al inicializar: respeta store / DOM (sin flash a dark).
+	 * @returns {'light' | 'dark'}
+	 */
+	_resolveInitialMapTheme() {
+		try {
+			const t = get(theme);
+			if (t === 'light' || t === 'dark') return t;
+		} catch {
+			/* store aún no disponible */
+		}
+		if (typeof document !== 'undefined') {
+			if (document.documentElement.classList.contains('dark')) return 'dark';
+			if (document.documentElement.dataset.theme === 'light') return 'light';
+			if (document.documentElement.dataset.theme === 'dark') return 'dark';
+		}
+		return 'dark';
+	}
+
+	/**
 	 * @param {'light' | 'dark'} mode
 	 */
 	setMapTheme(mode) {
@@ -1128,9 +1159,7 @@ class MapService {
 	 */
 	enableMobileZoneEditorZoomLock() {
 		if (!this.map || this._mobileZoneZoomLocked) return;
-		const isMobileLayout =
-			typeof window !== 'undefined' && window.matchMedia('(max-width: 639px)').matches;
-		if (!isMobileLayout) return;
+		if (!this._isMobileLayout()) return;
 		const z = this._mobileZoneEditorZoom;
 		this._mobileZoneZoomLocked = true;
 		this.map.setOptions({

--- a/src/lib/services/positionService.js
+++ b/src/lib/services/positionService.js
@@ -200,7 +200,8 @@ class PositionService {
 			engineStatus,
 			satellites,
 			rxLvl,
-			mainBatteryVoltage
+			mainBatteryVoltage,
+			backupBatteryVoltage
 		};
 	}
 

--- a/src/lib/stores/vehicleStore.js
+++ b/src/lib/stores/vehicleStore.js
@@ -7,6 +7,8 @@ import { colorSlugToHex, formatLastUpdate } from '$lib/utils/vehicleUtils.js';
 // Estado principal de vehículos
 export const vehicles = writable([]);
 export const selectedVehicles = writable([]);
+/** IDs de unidades visibles en el mapa (marcadores). */
+export const mapVisibleUnitIds = writable([]);
 export const activeUnitId = writable(null);
 export const loadingVehicles = writable(false);
 export const vehiclePositions = writable(new Map());
@@ -23,6 +25,21 @@ export const activeUnit = derived([vehicles, activeUnitId], ([$vehicles, $active
 
 // Store derivado para contar vehículos seleccionados
 export const selectedVehicleCount = derived(selectedVehicles, ($selected) => $selected.length);
+
+export const mapVisibleUnitCount = derived(mapVisibleUnitIds, ($ids) => $ids.length);
+
+/** Sincroniza visibilidad: nuevas unidades visibles; elimina IDs que ya no existen. */
+function syncMapVisibleIds(vehicleList) {
+	const ids = vehicleList.map((v) => String(v?.id || '')).filter(Boolean);
+	const idSet = new Set(ids);
+	mapVisibleUnitIds.update((prev) => {
+		if (!Array.isArray(prev) || prev.length === 0) return ids;
+		const kept = prev.filter((id) => idSet.has(String(id)));
+		const keptSet = new Set(kept);
+		const added = ids.filter((id) => !keptSet.has(id));
+		return [...kept, ...added];
+	});
+}
 
 function hasVehicleCoords(v) {
 	const lat = v.latitude ?? v.lat;
@@ -159,11 +176,14 @@ export const vehicleActions = {
 		try {
 			const unitList = await apiService.getVehicles();
 			const apiVehicles = Array.isArray(unitList) ? unitList.map(mapUnitToVehicle) : [];
-			vehicles.set(mergeVehicleLists(apiVehicles));
+			const merged = mergeVehicleLists(apiVehicles);
+			vehicles.set(merged);
+			syncMapVisibleIds(merged);
 			await this.loadVehiclePositions();
 		} catch (error) {
 			console.error('Error cargando unidades desde API:', error);
 			vehicles.set([]);
+			mapVisibleUnitIds.set([]);
 		} finally {
 			loadingVehicles.set(false);
 		}
@@ -209,7 +229,8 @@ export const vehicleActions = {
 								engineStatus: position.engineStatus,
 								satellites: position.satellites,
 								rxLvl: position.rxLvl,
-								mainBatteryVoltage: position.mainBatteryVoltage
+								mainBatteryVoltage: position.mainBatteryVoltage,
+								backupBatteryVoltage: position.backupBatteryVoltage
 							};
 						}
 					}
@@ -259,7 +280,10 @@ export const vehicleActions = {
 		);
 
 		if (updatedVehicle && mapService.map) {
-			mapService.updateVehicleMarker(updatedVehicle);
+			const visible = get(mapVisibleUnitIds);
+			if (visible.includes(String(updatedVehicle.id))) {
+				mapService.updateVehicleMarker(updatedVehicle);
+			}
 		}
 	},
 
@@ -292,7 +316,8 @@ export const vehicleActions = {
 							engineStatus: position.engineStatus,
 							satellites: position.satellites,
 							rxLvl: position.rxLvl,
-							mainBatteryVoltage: position.mainBatteryVoltage
+							mainBatteryVoltage: position.mainBatteryVoltage,
+							backupBatteryVoltage: position.backupBatteryVoltage
 						};
 					}
 					return vehicle;
@@ -327,6 +352,53 @@ export const vehicleActions = {
 	// Limpiar selección
 	clearSelection() {
 		selectedVehicles.set([]);
+	},
+
+	/** ¿La unidad se muestra en el mapa? */
+	isVisibleOnMap(vehicleId) {
+		return get(mapVisibleUnitIds).includes(String(vehicleId));
+	},
+
+	toggleMapVisibility(vehicleId) {
+		const id = String(vehicleId ?? '');
+		if (!id) return;
+		mapVisibleUnitIds.update((ids) => {
+			if (ids.includes(id)) return ids.filter((x) => x !== id);
+			return [...ids, id];
+		});
+	},
+
+	setMapVisibility(vehicleId, visible) {
+		const id = String(vehicleId ?? '');
+		if (!id) return;
+		mapVisibleUnitIds.update((ids) => {
+			const has = ids.includes(id);
+			if (visible && !has) return [...ids, id];
+			if (!visible && has) return ids.filter((x) => x !== id);
+			return ids;
+		});
+	},
+
+	/** Muestra u oculta un conjunto de IDs (p. ej. resultados filtrados). */
+	setMapVisibilityForIds(vehicleIds, visible) {
+		const target = new Set((vehicleIds || []).map((id) => String(id)).filter(Boolean));
+		if (target.size === 0) return;
+		mapVisibleUnitIds.update((ids) => {
+			if (visible) {
+				const next = new Set(ids);
+				target.forEach((id) => next.add(id));
+				return [...next];
+			}
+			return ids.filter((id) => !target.has(id));
+		});
+	},
+
+	showAllOnMap() {
+		mapVisibleUnitIds.set(get(vehicles).map((v) => String(v.id)));
+	},
+
+	hideAllOnMap() {
+		mapVisibleUnitIds.set([]);
 	},
 
 	// Obtener vehículo por ID
@@ -373,6 +445,9 @@ export const vehicleActions = {
 			mapped.deviceId = payload.deviceId || payload.device_id;
 		}
 		vehicles.update((list) => [mapped, ...list.filter((v) => v.id !== mapped.id)]);
+		mapVisibleUnitIds.update((ids) =>
+			ids.includes(mapped.id) ? ids : [...ids, String(mapped.id)]
+		);
 		return mapped;
 	},
 
@@ -414,8 +489,10 @@ export const vehicleActions = {
 	async deleteVehicle(vehicleId) {
 		if (!vehicleId) return;
 		await apiService.deleteVehicle(vehicleId);
+		const id = String(vehicleId);
 		vehicles.update((list) => list.filter((v) => v.id !== vehicleId));
-		selectedVehicles.update((list) => list.filter((id) => id !== vehicleId));
+		selectedVehicles.update((list) => list.filter((x) => x !== vehicleId && x !== id));
+		mapVisibleUnitIds.update((list) => list.filter((x) => x !== id));
 	},
 
 	setActiveUnit(unitId) {

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -25,6 +25,7 @@
 	import MapContainer from '$lib/components/MapContainer.svelte';
 	import TopDrawer from '$lib/components/TopDrawer.svelte';
 	import DrawerConfiguracion from '$lib/components/DrawerConfiguracion.svelte';
+	import MapVisibleUnitsCard from '$lib/components/MapVisibleUnitsCard.svelte';
 	import AdminPanel from '$lib/components/AdminPanel.svelte';
 
 	import BottomTabBar from '$lib/components/BottomTabBar.svelte';
@@ -51,14 +52,9 @@
 
 	const sidebarBtnBase =
 		'relative flex h-12 w-12 shrink-0 cursor-pointer items-center justify-center rounded-[14px] border transition-[background-color,border-color,color,box-shadow] duration-200 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/70 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#080b16]';
-	const sidebarBtnIdle =
-		'border-transparent bg-slate-100 text-slate-500 hover:border-slate-300 hover:bg-slate-200 hover:text-slate-800 dark:bg-white/[0.04] dark:text-white/45 dark:hover:border-white/10 dark:hover:bg-white/[0.09] dark:hover:text-white/85';
-	const sidebarBtnDrawerActive =
-		'border-blue-500/40 bg-blue-50 text-blue-700 shadow-sm dark:border-blue-500/45 dark:bg-blue-600/[0.22] dark:text-blue-400 dark:shadow-[0_0_16px_rgba(37,99,235,0.25),inset_0_1px_0_rgba(255,255,255,0.08)]';
-	const sidebarBtnUserOpen =
-		'border-blue-400/40 bg-blue-50 text-blue-700 hover:border-blue-500/50 hover:bg-blue-100 dark:border-blue-500/30 dark:bg-blue-600/15 dark:text-blue-300 dark:hover:border-blue-500/40 dark:hover:bg-blue-600/20';
+	/** Idle / active en el markup (clases literales) para que Tailwind las detecte y Svelte reaccione a openDrawer. */
 	const baseConfigSidebarItems = [
-		{ id: 'unidades', label: 'Unidades', icon: 'mdi:car-side' },
+		{ id: 'unidades', label: 'Unidades', title: 'Seguimiento', icon: 'mdi:car-side' },
 		{ id: 'zonas', label: 'Zonas', icon: 'mdi:hexagon-multiple-outline' },
 		{ id: 'gestionar_alertas', label: 'Gestionar', icon: 'mdi:format-list-bulleted' },
 		{
@@ -106,8 +102,13 @@
 		openDrawer = openDrawer === drawerId ? '' : drawerId;
 	}
 
-	function isConfigDrawerActive(section) {
-		return openDrawer === getConfigDrawerId(section);
+	/** Clases de botón lateral: el caller debe pasar un booleano derivado de openDrawer en el template. */
+	function sidebarNavBtnClass(active) {
+		const idle =
+			'border-transparent bg-slate-100 text-slate-500 hover:border-slate-300 hover:bg-slate-200 hover:text-slate-800 dark:bg-white/[0.04] dark:text-white/45 dark:hover:border-white/10 dark:hover:bg-white/[0.09] dark:hover:text-white/85';
+		const activeCls =
+			'border-blue-600 bg-blue-600 text-white shadow-md shadow-blue-600/35 dark:border-blue-400/50 dark:bg-blue-500/25 dark:text-blue-300 dark:shadow-[0_0_18px_rgba(59,130,246,0.35)]';
+		return `${sidebarBtnBase} ${active ? activeCls : idle}`;
 	}
 
 	$: isConfigDrawerOpen = openDrawer.startsWith('configuracion:');
@@ -317,13 +318,17 @@
 			</a>
 		</header>
 
-		<div class="my-2 h-px w-9 shrink-0 bg-white/[0.08]" role="presentation"></div>
+		<div class="my-2 h-px w-9 shrink-0 bg-slate-200 dark:bg-white/[0.08]" role="presentation"></div>
 
 		<nav class="flex w-full flex-1 flex-col items-center gap-1 px-0" aria-label="Accesos rápidos">
 			<div class="relative w-full shrink-0 px-3" data-dashboard-user-menu>
 				<button
 					type="button"
-					class={`${sidebarBtnBase} mx-auto w-12 ${showUserMenu ? sidebarBtnUserOpen : sidebarBtnIdle}`}
+					class={`${sidebarBtnBase} mx-auto w-12 ${
+						showUserMenu
+							? 'border-blue-600 bg-blue-600 text-white shadow-md shadow-blue-600/35 dark:border-blue-400/50 dark:bg-blue-500/25 dark:text-blue-300'
+							: 'border-transparent bg-slate-100 text-slate-500 hover:border-slate-300 hover:bg-slate-200 hover:text-slate-800 dark:bg-white/[0.04] dark:text-white/45 dark:hover:border-white/10 dark:hover:bg-white/[0.09] dark:hover:text-white/85'
+					}`}
 					aria-expanded={showUserMenu}
 					aria-haspopup="true"
 					aria-controls="dashboard-user-menu"
@@ -376,7 +381,7 @@
 											type="button"
 											class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border text-slate-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/55 dark:text-white/70
 												{isConfigDrawerOpen && activeConfigSection === 'apariencia'
-												? 'border-blue-500/45 bg-blue-600/22 text-blue-300 shadow-[0_0_12px_rgba(37,99,235,0.25)]'
+												? 'border-blue-600 bg-blue-600 text-white shadow-md shadow-blue-600/25 dark:border-blue-500/45 dark:bg-blue-600/22 dark:text-blue-300 dark:shadow-[0_0_12px_rgba(37,99,235,0.25)]'
 												: 'border-slate-200 bg-slate-100 hover:border-slate-300 hover:bg-slate-200 hover:text-slate-900 dark:border-white/[0.12] dark:bg-white/[0.06] dark:hover:border-white/20 dark:hover:bg-white/[0.1] dark:hover:text-white'}"
 											aria-label="Configuración"
 											title="Configuración"
@@ -416,29 +421,48 @@
 			<div class="flex flex-col items-center gap-1">
 				<button
 					type="button"
-					class={`${sidebarBtnBase} mx-auto ${openDrawer === 'informes' ? sidebarBtnDrawerActive : sidebarBtnIdle}`}
+					class="{sidebarNavBtnClass(openDrawer === 'informes')} mx-auto"
 					aria-label="Abrir informes"
 					aria-pressed={openDrawer === 'informes'}
 					title="Informes"
 					on:click={() => toggleDrawer('informes')}
 				>
+					{#if openDrawer === 'informes'}
+						<span
+							class="absolute -left-1 top-1/2 h-7 w-1 -translate-y-1/2 rounded-r-full bg-blue-600 dark:bg-blue-400"
+							aria-hidden="true"
+						></span>
+					{/if}
 					<Icon
 						icon="mdi:file-chart-outline"
-						class="h-[22px] w-[22px] shrink-0"
+						class="h-[22px] w-[22px] shrink-0 {openDrawer === 'informes'
+							? 'text-white dark:text-blue-300'
+							: ''}"
 						aria-hidden="true"
 					/>
 				</button>
 
 				{#each configSidebarItems as item (item.id)}
+					{@const itemActive = openDrawer === `configuracion:${item.id}`}
 					<button
 						type="button"
-						class={`${sidebarBtnBase} mx-auto ${isConfigDrawerActive(item.id) ? sidebarBtnDrawerActive : sidebarBtnIdle}`}
+						class="{sidebarNavBtnClass(itemActive)} mx-auto"
 						aria-label={item.title ?? `Abrir ${item.label}`}
-						aria-pressed={isConfigDrawerActive(item.id)}
+						aria-pressed={itemActive}
 						title={item.title ?? item.label}
 						on:click={() => openConfigDrawer(item.id)}
 					>
-						<Icon icon={item.icon} class="h-[22px] w-[22px] shrink-0" aria-hidden="true" />
+						{#if itemActive}
+							<span
+								class="absolute -left-1 top-1/2 h-7 w-1 -translate-y-1/2 rounded-r-full bg-blue-600 dark:bg-blue-400"
+								aria-hidden="true"
+							></span>
+						{/if}
+						<Icon
+							icon={item.icon}
+							class="h-[22px] w-[22px] shrink-0 {itemActive ? 'text-white dark:text-blue-300' : ''}"
+							aria-hidden="true"
+						/>
 					</button>
 				{/each}
 			</div>
@@ -448,7 +472,7 @@
 			{#if browser}
 				<button
 					type="button"
-					class={`${sidebarBtnBase} mx-auto h-[42px] w-[42px] rounded-[10px] ${sidebarBtnIdle}`}
+					class={`${sidebarBtnBase} mx-auto h-[42px] w-[42px] rounded-[10px] border-transparent bg-slate-100 text-slate-500 hover:border-slate-300 hover:bg-slate-200 hover:text-slate-800 dark:bg-white/[0.04] dark:text-white/45 dark:hover:border-white/10 dark:hover:bg-white/[0.09] dark:hover:text-white/85`}
 					on:click={toggleFullscreen}
 					aria-label={isAppFullscreen ? 'Salir de pantalla completa' : 'Pantalla completa'}
 					title={isAppFullscreen ? 'Salir' : 'Pantalla completa'}
@@ -490,14 +514,22 @@
 		<TopDrawer
 			open={isConfigDrawerOpen}
 			title={configDrawerTitle}
+			subtitle={activeConfigSection === 'unidades'
+				? 'Visualiza y administra tus unidades en tiempo real'
+				: ''}
 			icon={activeConfigSection === 'administracion'
 				? 'mdi:shield-account-outline'
-				: 'mdi:cog-outline'}
+				: activeConfigSection === 'unidades'
+					? 'mdi:car-side'
+					: 'mdi:cog-outline'}
 			accentColor={activeConfigSection === 'administracion' ? '#2563eb' : '#10b981'}
 			sidebarWidth={SW}
 			bodyPaddingClass={activeConfigSection === 'administracion' ? 'py-4 px-0' : 'p-0'}
 			bodyScrollable={activeConfigSection !== 'zonas' && activeConfigSection !== 'unidades'}
-			passiveBackdrop={$mobileCrearZonaMapPassesPointer || $desktopZonePanelSubView !== 'zonas'}
+			placement={activeConfigSection === 'unidades' ? 'side' : 'bottom'}
+			passiveBackdrop={$mobileCrearZonaMapPassesPointer ||
+				$desktopZonePanelSubView !== 'zonas' ||
+				activeConfigSection === 'unidades'}
 			on:close={closeDrawer}
 		>
 			{#if activeConfigSection === 'administracion'}
@@ -514,6 +546,15 @@
 			{/if}
 		</TopDrawer>
 
+		{#if isConfigDrawerOpen && activeConfigSection === 'unidades'}
+			<div
+				class="pointer-events-none fixed right-4 top-4 z-[115] hidden lg:block"
+				aria-hidden="false"
+			>
+				<MapVisibleUnitsCard />
+			</div>
+		{/if}
+
 		{#if $desktopZonePanelSubView !== 'zonas'}
 			<ZonasPanel variant="desktop" useDesktopOverlayStore={true} />
 		{/if}
@@ -521,8 +562,10 @@
 		<!-- PR-04: TrackingContextPanel flotante para desktop/tablet -->
 		{#if $activeUnit && !isConfigDrawerOpen && openDrawer !== 'informes'}
 			<div class="pointer-events-none fixed bottom-24 right-4 z-[100] hidden w-[340px] md:block">
-				<div class="pointer-events-auto overflow-hidden rounded-2xl shadow-2xl">
-					<div class="max-h-[70vh] bg-[#0c1829]">
+				<div
+					class="pointer-events-auto overflow-hidden rounded-2xl border border-slate-200/80 shadow-xl dark:border-transparent dark:shadow-2xl"
+				>
+					<div class="max-h-[70vh] bg-white dark:bg-[#0c1829]">
 						<TrackingSubPanel
 							unit={$activeUnit}
 							units={$vehicles}
@@ -628,7 +671,7 @@
 			transition:fly={{ y: 20, duration: 200, easing: cubicOut }}
 		>
 			<div
-				class="max-h-[60vh] overflow-hidden rounded-2xl bg-[#0c1829] shadow-[0_-4px_20px_rgba(0,0,0,0.5)]"
+				class="max-h-[60vh] overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-[0_-4px_20px_rgba(15,23,42,0.12)] dark:border-transparent dark:bg-[#0c1829] dark:shadow-[0_-4px_20px_rgba(0,0,0,0.5)]"
 			>
 				<TrackingSubPanel
 					unit={$activeUnit}


### PR DESCRIPTION
## Summary
- Redesign seguimiento units list with telemetry cards, filters, map visibility toggles, and dual light/dark styling across tracking panels and reports unit picker
- Responsive: tablet uses bottom sheet for seguimiento; floating “Unidades visibles” only on desktop (lg+); hide vehicle InfoWindow on mobile; collapsible trip stats on mobile
- Map initializes with the user’s saved theme (no dark flash); early theme script in app.html
