### PR TITLE
feat: enlaces legales y tipografías auto-alojadas

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,9 @@ VITE_COMM_API_URL=http://localhost:8000
 # Admin API (si difiere de VITE_API_BASE_URL)
 VITE_ADMIN_API_URL=http://localhost:8100/api/v1
 
-# URL pública de la app (recuperación de contraseña, etc.)
-VITE_COMPANY_URL=http://localhost:5173
+# Sitio corporativo (auth centralizado, /legal/*). En local: geminis-labs-web-page.
+# Si queda vacío, los enlaces legales usan https://www.geminislabs.com
+VITE_COMPANY_URL=http://localhost:5174
 
 # Google Maps API Key
 VITE_GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `docs/requerimientos/enlaces-legales-y-tipografias.md`: specification to hand over the work of linking the published legal documents from the app and self-hosting the fonts. NEXUS writes to the user's device before a session even exists, yet there is no legal link anywhere in login, registration, password recovery or the user menu. Also covers removing the obsolete `.docx` under `docs/legal/`, superseded by the corporate set
+- Legal document links (Privacidad, Términos, Aviso legal, Cookies) on login, register, forgot/reset password, and the signed-in user menu — shared `EnlacesLegales` component; URLs from `src/lib/constants/legal.js` (`VITE_COMPANY_URL`, fallback `https://www.geminislabs.com`)
+- Unit tests for legal URL constants (`tests/legal.test.js`)
+- `docs/requerimientos/enlaces-legales-y-tipografias.md` — requirement spec for legal linking and font self-hosting
 
 - Map layers menu (Mapa / Satélite / Híbrido / Relieve + tráfico en vivo) and custom zoom controls matching app look
 - Street View: custom exit control below WorkspaceSwitcher; native pegman with theme-aware background
@@ -36,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expand button on report charts: opens each chart in a horizontally scrollable modal showing every bucket label
 
 ### Changed
+
+- Admin workspace fonts (Sora, IBM Plex Sans) are self-hosted via Fontsource (`latin` / `latin-ext` weights in use only); removed Google Fonts CDN `<link>` tags from `AdminWorkspace.svelte` so the browser no longer sends the user IP to Google for typography
+- `.env.example`: clarify that `VITE_COMPANY_URL` is the corporate site base (auth + `/legal/*`), not the NEXUS app origin
 
 - Signal intensity classified as Malo/Regular/Bueno (red/yellow/green only) across telemetry chips and map InfoWindow
 - Telemetry chips now show icons and clearer texts: Batería (V), Respaldo (V), Satélites, Señal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,4 +104,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Bump `@sveltejs/kit` to `2.70.2` (GHSA-29g2-3rmr-qm68 / OSV medium)
 - **Rotate** any Google Maps API key that was previously committed in git history (GCP Console → Credentials)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
 			"name": "tracker-monitor-app",
 			"version": "0.0.1",
 			"dependencies": {
+				"@fontsource/ibm-plex-sans": "^5.3.0",
+				"@fontsource/sora": "^5.3.0",
 				"@googlemaps/js-api-loader": "^1.16.10",
 				"@googlemaps/markerclusterer": "^2.6.2",
 				"@iconify/svelte": "^5.2.1",
@@ -1057,6 +1059,24 @@
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@fontsource/ibm-plex-sans": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-sans/-/ibm-plex-sans-5.3.0.tgz",
+			"integrity": "sha512-CbE4CbbEEZJX860XyUiRpsksXIQR8Rp2XDva2VO53NJox9tVNtusrysd2x5YkUEY3ErQ66W1IiiQL8/wihhw5w==",
+			"license": "OFL-1.1",
+			"funding": {
+				"url": "https://github.com/sponsors/ayuhito"
+			}
+		},
+		"node_modules/@fontsource/sora": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@fontsource/sora/-/sora-5.3.0.tgz",
+			"integrity": "sha512-SqW3OpKxxfKvxDLPlbdrWf2KooPfbd+W3jaYn483o+Y/JrmU87vjFPNptDqwP428c3vY+gnranLhjcbRaXB0Jw==",
+			"license": "OFL-1.1",
+			"funding": {
+				"url": "https://github.com/sponsors/ayuhito"
 			}
 		},
 		"node_modules/@googlemaps/js-api-loader": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"@playwright/test": "^1.56.1",
 				"@sveltejs/adapter-auto": "^6.0.0",
 				"@sveltejs/adapter-node": "^5.5.4",
-				"@sveltejs/kit": "^2.22.0",
+				"@sveltejs/kit": "^2.70.2",
 				"@sveltejs/vite-plugin-svelte": "^6.0.0",
 				"@tailwindcss/postcss": "^4.1.13",
 				"@tailwindcss/typography": "^0.5.16",
@@ -1851,9 +1851,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.70.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.70.1.tgz",
-			"integrity": "sha512-nY9SPHGOZro3doud9vZXDBwl9tCZIouuJztjgSHs6PAIrv9M/z5O7eOhPV5xU7CgVHA976Jwu3BA1hIFvXztkA==",
+			"version": "2.70.2",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.70.2.tgz",
+			"integrity": "sha512-RzRoRpuR2KXqc5yMO0akQHDZeT4AslOlznGITURsqHaVbtyYP4Wn3eE3gxj9JcDyNYO0crkxhdwFHc+2vkVm6w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
 		"@commitlint/config-conventional": "^19.8.1",
 		"@eslint/js": "^9.39.1",
 		"@playwright/test": "^1.56.1",
-		"@vitest/coverage-v8": "^3.2.4",
 		"@sveltejs/adapter-auto": "^6.0.0",
 		"@sveltejs/adapter-node": "^5.5.4",
 		"@sveltejs/kit": "^2.22.0",
@@ -48,6 +47,7 @@
 		"@tailwindcss/postcss": "^4.1.13",
 		"@tailwindcss/typography": "^0.5.16",
 		"@types/node": "^25.9.1",
+		"@vitest/coverage-v8": "^3.2.4",
 		"autoprefixer": "^10.4.21",
 		"eslint": "^9.39.1",
 		"eslint-config-prettier": "^10.1.8",
@@ -67,6 +67,8 @@
 		"vitest": "^3.2.4"
 	},
 	"dependencies": {
+		"@fontsource/ibm-plex-sans": "^5.3.0",
+		"@fontsource/sora": "^5.3.0",
 		"@googlemaps/js-api-loader": "^1.16.10",
 		"@googlemaps/markerclusterer": "^2.6.2",
 		"@iconify/svelte": "^5.2.1",

--- a/src/lib/components/EnlacesLegales.svelte
+++ b/src/lib/components/EnlacesLegales.svelte
@@ -1,0 +1,56 @@
+<script>
+	import { getLegalLinks } from '$lib/constants/legal.js';
+
+	/** @type {'compact' | 'list'} */
+	export let variant = 'compact';
+
+	const links = getLegalLinks();
+
+	const linkClass =
+		'rounded-sm font-medium text-slate-700 underline-offset-2 transition-colors hover:text-slate-900 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-slate-200 dark:hover:text-white';
+</script>
+
+{#if variant === 'list'}
+	<nav aria-label="Documentos legales" class="space-y-1">
+		<p
+			class="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
+		>
+			Legal
+		</p>
+		<ul class="m-0 list-none space-y-0.5 p-0">
+			{#each links as link (link.id)}
+				<li>
+					<a
+						href={link.href}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="flex min-h-[2.5rem] items-center rounded-lg px-3 py-2 text-sm {linkClass} no-underline hover:bg-slate-100 dark:hover:bg-white/[0.06]"
+					>
+						{link.label}
+						<span class="sr-only"> (se abre en una pestaña nueva)</span>
+					</a>
+				</li>
+			{/each}
+		</ul>
+	</nav>
+{:else}
+	<nav
+		aria-label="Documentos legales"
+		class="flex flex-wrap items-center justify-center gap-x-1.5 gap-y-1 text-[0.75rem] leading-snug"
+	>
+		{#each links as link, i (link.id)}
+			{#if i > 0}
+				<span class="select-none text-slate-400 dark:text-white/35" aria-hidden="true">·</span>
+			{/if}
+			<a
+				href={link.href}
+				target="_blank"
+				rel="noopener noreferrer"
+				class="{linkClass} no-underline"
+			>
+				{link.label}
+				<span class="sr-only"> (se abre en una pestaña nueva)</span>
+			</a>
+		{/each}
+	</nav>
+{/if}

--- a/src/lib/components/UserPanel.svelte
+++ b/src/lib/components/UserPanel.svelte
@@ -2,6 +2,7 @@
 	import { goto } from '$app/navigation';
 	import Icon from '@iconify/svelte';
 	import CenterSheet from '$lib/components/CenterSheet.svelte';
+	import EnlacesLegales from '$lib/components/EnlacesLegales.svelte';
 	import { logoutSession } from '$lib/services/sessionService.js';
 	import { theme, themeActions } from '$lib/stores/themeStore.js';
 
@@ -134,6 +135,13 @@
 					No hay información de usuario disponible.
 				</p>
 			{/if}
+		</section>
+
+		<section
+			class="rounded-xl border border-slate-200 bg-white/95 p-4 text-slate-800 shadow-sm dark:border-slate-600 dark:bg-slate-800/90 dark:text-slate-100"
+			aria-label="Información legal"
+		>
+			<EnlacesLegales variant="list" />
 		</section>
 
 		<button

--- a/src/lib/components/admin/AdminWorkspace.svelte
+++ b/src/lib/components/admin/AdminWorkspace.svelte
@@ -15,6 +15,20 @@
 	import TabInformes from '$lib/components/TabInformes.svelte';
 	import DrawerConfiguracion from '$lib/components/DrawerConfiguracion.svelte';
 
+	/* Tipografías auto-alojadas (latin/latin-ext): evita transferir la IP a Google Fonts. */
+	import '@fontsource/sora/latin-500.css';
+	import '@fontsource/sora/latin-600.css';
+	import '@fontsource/sora/latin-700.css';
+	import '@fontsource/sora/latin-ext-500.css';
+	import '@fontsource/sora/latin-ext-600.css';
+	import '@fontsource/sora/latin-ext-700.css';
+	import '@fontsource/ibm-plex-sans/latin-400.css';
+	import '@fontsource/ibm-plex-sans/latin-500.css';
+	import '@fontsource/ibm-plex-sans/latin-600.css';
+	import '@fontsource/ibm-plex-sans/latin-ext-400.css';
+	import '@fontsource/ibm-plex-sans/latin-ext-500.css';
+	import '@fontsource/ibm-plex-sans/latin-ext-600.css';
+
 	const navItems = [
 		{ id: 'dashboard', label: 'Dashboard', icon: 'mdi:view-dashboard-outline' },
 		{ id: 'users', label: 'Usuarios', icon: 'mdi:account-group-outline' },
@@ -56,15 +70,6 @@
 		if (window.matchMedia('(max-width: 639px)').matches) collapsed = true;
 	});
 </script>
-
-<svelte:head>
-	<link rel="preconnect" href="https://fonts.googleapis.com" />
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
-	<link
-		href="https://fonts.googleapis.com/css2?family=Sora:wght@500;600;700&family=IBM+Plex+Sans:wght@400;500;600&display=swap"
-		rel="stylesheet"
-	/>
-</svelte:head>
 
 <svelte:window on:click={onDocClick} />
 

--- a/src/lib/constants/legal.js
+++ b/src/lib/constants/legal.js
@@ -1,0 +1,31 @@
+/**
+ * URLs del juego documental legal corporativo (geminislabs.com).
+ * Fuente única: no duplicar estos paths en plantillas.
+ */
+
+const FALLBACK_COMPANY_URL = 'https://www.geminislabs.com';
+
+/**
+ * @returns {string} Origen del sitio corporativo sin barra final.
+ */
+export function getCompanyBaseUrl() {
+	const fromEnv = String(import.meta.env.VITE_COMPANY_URL || '')
+		.trim()
+		.replace(/\/$/, '');
+	return fromEnv || FALLBACK_COMPANY_URL;
+}
+
+/** @typedef {{ id: string, label: string, href: string }} LegalLink */
+
+/**
+ * @returns {readonly LegalLink[]}
+ */
+export function getLegalLinks() {
+	const base = getCompanyBaseUrl();
+	return Object.freeze([
+		{ id: 'privacidad', label: 'Privacidad', href: `${base}/legal/privacidad` },
+		{ id: 'terminos', label: 'Términos', href: `${base}/legal/terminos` },
+		{ id: 'aviso-legal', label: 'Aviso legal', href: `${base}/legal/aviso-legal` },
+		{ id: 'cookies', label: 'Cookies', href: `${base}/legal/cookies` }
+	]);
+}

--- a/src/routes/forgot-password/+page.svelte
+++ b/src/routes/forgot-password/+page.svelte
@@ -3,6 +3,7 @@
 	import { apiService } from '$lib/services/api.js';
 	import Icon from '@iconify/svelte';
 	import logoUrl from '$lib/assets/logo.png';
+	import EnlacesLegales from '$lib/components/EnlacesLegales.svelte';
 
 	let email = '';
 	let loading = false;
@@ -94,5 +95,8 @@
 				>Volver al inicio de sesión</a
 			>
 		</p>
+		<div class="mt-4 w-full border-t border-slate-200 pt-4 dark:border-white/10">
+			<EnlacesLegales variant="compact" />
+		</div>
 	</main>
 </div>

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -8,6 +8,7 @@
 	import { onMount } from 'svelte';
 	import Icon from '@iconify/svelte';
 	import logoUrl from '$lib/assets/logo.png';
+	import EnlacesLegales from '$lib/components/EnlacesLegales.svelte';
 
 	let email = '';
 	let password = '';
@@ -107,9 +108,12 @@
 		>
 			NEXUS
 		</h1>
-		<p class="mb-8 mt-0 text-center text-sm tracking-wide text-slate-600 dark:text-white/45">
+		<p class="mb-3 mt-0 text-center text-sm tracking-wide text-slate-600 dark:text-white/45">
 			by GeminisLabs
 		</p>
+		<div class="mb-8 w-full">
+			<EnlacesLegales variant="compact" />
+		</div>
 
 		<form
 			class="flex w-full flex-col gap-4"

--- a/src/routes/register/+page.svelte
+++ b/src/routes/register/+page.svelte
@@ -6,6 +6,7 @@
 	import { onMount } from 'svelte';
 	import Icon from '@iconify/svelte';
 	import logoUrl from '$lib/assets/logo.png';
+	import EnlacesLegales from '$lib/components/EnlacesLegales.svelte';
 
 	const inputClass =
 		'w-full appearance-none rounded-[14px] border border-slate-200 bg-white py-3.5 pl-[2.875rem] text-[0.9375rem] text-slate-900 outline-none transition-[border-color,background-color,box-shadow] duration-200 placeholder:text-slate-400 focus:border-blue-500 focus:bg-white focus:ring-[3px] focus:ring-blue-500/15 dark:border-white/15 dark:bg-white/[0.08] dark:text-white dark:placeholder:text-white/30 dark:focus:border-blue-500/70 dark:focus:bg-white/11';
@@ -117,9 +118,12 @@
 		>
 			NEXUS
 		</h1>
-		<p class="mb-8 mt-0 text-center text-sm tracking-wide text-slate-600 dark:text-white/45">
+		<p class="mb-3 mt-0 text-center text-sm tracking-wide text-slate-600 dark:text-white/45">
 			Crear cuenta
 		</p>
+		<div class="mb-8 w-full">
+			<EnlacesLegales variant="compact" />
+		</div>
 
 		<form
 			class="flex w-full flex-col gap-4"

--- a/src/routes/reset-password/+page.svelte
+++ b/src/routes/reset-password/+page.svelte
@@ -5,6 +5,7 @@
 	import { validatePassword } from '$lib/utils/passwordValidation.js';
 	import Icon from '@iconify/svelte';
 	import logoUrl from '$lib/assets/logo.png';
+	import EnlacesLegales from '$lib/components/EnlacesLegales.svelte';
 	import { onMount } from 'svelte';
 
 	let email = '';
@@ -174,5 +175,8 @@
 				>Iniciar sesión</a
 			>
 		</p>
+		<div class="mt-4 w-full border-t border-slate-200 pt-4 dark:border-white/10">
+			<EnlacesLegales variant="compact" />
+		</div>
 	</main>
 </div>

--- a/tests/legal.test.js
+++ b/tests/legal.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('legal constants', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.unstubAllEnvs();
+	});
+
+	it('usa VITE_COMPANY_URL como base de los cuatro documentos', async () => {
+		vi.stubEnv('VITE_COMPANY_URL', 'https://geminis.dev/');
+		const { getLegalLinks, getCompanyBaseUrl } = await import('../src/lib/constants/legal.js');
+		expect(getCompanyBaseUrl()).toBe('https://geminis.dev');
+		expect(getLegalLinks().map((l) => l.href)).toEqual([
+			'https://geminis.dev/legal/privacidad',
+			'https://geminis.dev/legal/terminos',
+			'https://geminis.dev/legal/aviso-legal',
+			'https://geminis.dev/legal/cookies'
+		]);
+	});
+
+	it('hace fallback a geminislabs.com si no hay VITE_COMPANY_URL', async () => {
+		vi.stubEnv('VITE_COMPANY_URL', '');
+		const { getCompanyBaseUrl, getLegalLinks } = await import('../src/lib/constants/legal.js');
+		expect(getCompanyBaseUrl()).toBe('https://www.geminislabs.com');
+		expect(getLegalLinks()).toHaveLength(4);
+		expect(
+			getLegalLinks().every((l) => l.href.startsWith('https://www.geminislabs.com/legal/'))
+		).toBe(true);
+	});
+
+	it('expone ids y etiquetas estables', async () => {
+		vi.stubEnv('VITE_COMPANY_URL', 'https://example.com');
+		const { getLegalLinks } = await import('../src/lib/constants/legal.js');
+		expect(getLegalLinks().map((l) => l.id)).toEqual([
+			'privacidad',
+			'terminos',
+			'aviso-legal',
+			'cookies'
+		]);
+		expect(getLegalLinks().map((l) => l.label)).toEqual([
+			'Privacidad',
+			'Términos',
+			'Aviso legal',
+			'Cookies'
+		]);
+	});
+});


### PR DESCRIPTION
## ¿Qué hace este PR?
Enlaza los cuatro documentos legales corporativos desde login, registro, recuperación de contraseña y el menú de usuario. Auto-aloja Sora e IBM Plex Sans con Fontsource y elimina las cargas a Google Fonts del workspace de admin.

## Notas
- Las peticiones a `fonts.googleapis.com` de Inter/Roboto vienen de Google Maps JS API, no de este cambio.