### PR TITLE
fix(security): override de nanoid y mínimo real de @sveltejs/kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Added a `nanoid` override (`>=3.3.17`) for GHSA-2v37-7h3g-55p8. The advisory was published after the last green build and broke CI on `develop` in both the `quality` (npm audit) and `security` (OSV) jobs. It reaches the tree through `postcss`
+- Raised the `@sveltejs/kit` floor in `package.json` from `^2.22.0` to `^2.70.2`. The fix for GHSA-29g2-3rmr-qm68 lived only in the lockfile, so any `npm install` could resolve back to a vulnerable 2.x and silently undo it. Production was never exposed — the Dockerfile uses `npm ci` — but local environments were
+
 ### Added
 
 - Legal document links (Privacidad, Términos, Aviso legal, Cookies) on login, register, forgot/reset password, and the signed-in user menu — shared `EnlacesLegales` component; URLs from `src/lib/constants/legal.js` (`VITE_COMPANY_URL`, fallback `https://www.geminislabs.com`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1856,6 +1856,7 @@
 			"integrity": "sha512-RzRoRpuR2KXqc5yMO0akQHDZeT4AslOlznGITURsqHaVbtyYP4Wn3eE3gxj9JcDyNYO0crkxhdwFHc+2vkVm6w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@sveltejs/acorn-typescript": "^1.0.9",
@@ -1908,6 +1909,7 @@
 			"integrity": "sha512-4jfkfvsGI+U2OhHX8OPCKtMCf7g7ledXhs3E6UcA4EY0jQWsiVbe83pTAHp9XTifzYNOiD4AJieJUsI0qqxsbw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
 				"debug": "^4.4.1",
@@ -4421,6 +4423,7 @@
 			"integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": ">=7.24.0 <7.24.7"
 			}
@@ -4628,6 +4631,7 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -4886,6 +4890,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"caniuse-lite": "^1.0.30001737",
 				"electron-to-chromium": "^1.5.211",
@@ -5301,6 +5306,7 @@
 			"integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"env-paths": "^2.2.1",
 				"import-fresh": "^3.3.0",
@@ -5651,6 +5657,7 @@
 			"integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -6457,6 +6464,7 @@
 			"integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/node": ">=20.0.0",
 				"@types/whatwg-mimetype": "^3.0.2",
@@ -7601,9 +7609,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.16",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+			"version": "5.1.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+			"integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -7613,10 +7621,10 @@
 			],
 			"license": "MIT",
 			"bin": {
-				"nanoid": "bin/nanoid.cjs"
+				"nanoid": "bin/nanoid.js"
 			},
 			"engines": {
-				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+				"node": "^18 || >=20"
 			}
 		},
 		"node_modules/natural-compare": {
@@ -7969,6 +7977,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
@@ -8119,6 +8128,7 @@
 			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -8283,6 +8293,7 @@
 			"integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -8679,6 +8690,7 @@
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.1.tgz",
 			"integrity": "sha512-eArsJmvl3xZVuTYD852PzIEdg2wgDdIZ1NEsIPbzAukHwi284B18No4nK2rCO9AwsWUDza4Cjvmoa4HaojTl5g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -8785,7 +8797,8 @@
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
 			"integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/tapable": {
 			"version": "2.2.3",
@@ -9010,6 +9023,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -9092,6 +9106,7 @@
 			"integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -9210,6 +9225,7 @@
 			"integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/chai": "^5.2.2",
 				"@vitest/expect": "3.2.7",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"@playwright/test": "^1.56.1",
 		"@sveltejs/adapter-auto": "^6.0.0",
 		"@sveltejs/adapter-node": "^5.5.4",
-		"@sveltejs/kit": "^2.22.0",
+		"@sveltejs/kit": "^2.70.2",
 		"@sveltejs/vite-plugin-svelte": "^6.0.0",
 		"@tailwindcss/postcss": "^4.1.13",
 		"@tailwindcss/typography": "^0.5.16",
@@ -83,6 +83,7 @@
 		"fast-uri": ">=4.1.2",
 		"tar": ">=7.5.19",
 		"brace-expansion": "5.0.9",
-		"minimatch@9": "10.2.6"
+		"minimatch@9": "10.2.6",
+		"nanoid": ">=3.3.17"
 	}
 }


### PR DESCRIPTION
**CI lleva en rojo en `develop` desde el merge del PR #38, y no por ese PR.**

## nanoid — lo que rompe el CI ahora

El aviso [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) sobre `nanoid <3.3.17` se publicó **después del último build verde**. Rompe los dos trabajos que auditan:

```
quality   Audit dependencies  → nanoid <3.3.17 · 1 high severity vulnerability
security  OSV dependency scan → 1 package affected by 1 known vulnerability
```

Llega al árbol por `postcss`, así que se ataja con un override a `>=3.3.17`. Comprobado que también existe en `develop` sin ningún cambio mío: es preexistente, no introducido por este PR ni por el anterior.

## @sveltejs/kit — el que casi se deshace solo

El commit `811e992` arregló GHSA-29g2-3rmr-qm68 subiendo la versión, pero **el arreglo vivía únicamente en el lockfile**:

| | |
|---|---|
| `package.json` | `"@sveltejs/kit": "^2.22.0"` |
| `package-lock.json` | instalada `2.70.2` |

`^2.22.0` admite cualquier 2.x, así que un `npm install` puede resolver a una versión anterior y **deshacer el parche sin que nadie se entere**. Estuvo a punto de pasarme al revisar el PR #38: mi `npm install` reescribió esa línea del lockfile y lo detecté por casualidad al mirar el diff.

**Producción nunca estuvo expuesta** — el Dockerfile usa `npm ci`, que respeta el lockfile. El riesgo era para los entornos locales, y para el siguiente que corriera `npm install` sin mirar.

Se sube el mínimo en `package.json` a `^2.70.2`, que es la que ya estaba instalada. Las dos fuentes pasan a decir lo mismo.

## Verificación

```
npm run audit    found 0 vulnerabilities
npm run check    1119 archivos · 0 errores · 0 avisos
npm run test     16 archivos · 76 pruebas
npm run lint     limpio
npm run build    correcto
```

`nanoid` resuelve a 5.1.16 y `@sveltejs/kit` a 2.70.2.

## Nota

Debería desbloquear también el PR de Dependabot `dev-tooling`, que falla por la misma causa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)