### PR TITLE
feat(seguridad): credencial dedicada para el plano de datos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Credencial dedicada para el plano de datos (`src/lib/services/dataToken.js`). siscom-api deja de recibir el token de sesión de Cognito —que lleva identidad de usuario y sirve para toda la admin-api— y pasa a recibir un PASETO v4.public cuyo contenido es solo `{ jti, scope_ref, aud, iat, nbf, exp }`. El alcance vive en Valkey, así que el plano de datos autoriza sin poder saber de quién es la flota
+- Los WebSockets pasan la credencial por subprotocolo del handshake (`siscom.data-token.v1`) en vez de la query string: en v4.public el payload va en claro y una query acaba en los logs del ALB y en la cabecera `Referer`
+- El IMEI deja de viajar por el cable. `deviceRef` opaco sustituye a `device_id` en query strings y paths; `deviceId` se conserva solo para mostrar en pantalla
+- Tres estados diferenciados del plano de datos: 403 alcance rechazado (se reemite y reintenta una vez), 404 nada visible en el rango pedido (no se reintenta), 200 con lista vacía sin datos. Una lista vacía ante un rango sin permiso afirmaría que no hubo telemetría, cuando la hubo y no es visible
+- `eventService` deja de caer a un `http://localhost:8000` cableado si falta `VITE_COMM_API_URL`, igual que ya hacía `positionService`
+
 - Added a `nanoid` override (`>=3.3.17`) for GHSA-2v37-7h3g-55p8. The advisory was published after the last green build and broke CI on `develop` in both the `quality` (npm audit) and `security` (OSV) jobs. It reaches the tree through `postcss`
 - Raised the `@sveltejs/kit` floor in `package.json` from `^2.22.0` to `^2.70.2`. The fix for GHSA-29g2-3rmr-qm68 lived only in the lockfile, so any `npm install` could resolve back to a vulnerable 2.x and silently undo it. Production was never exposed — the Dockerfile uses `npm ci` — but local environments were
 

--- a/src/lib/components/MapContainer.svelte
+++ b/src/lib/components/MapContainer.svelte
@@ -14,7 +14,8 @@
 		vehicles,
 		vehicleActions,
 		activeUnitId,
-		mapVisibleUnitIds
+		mapVisibleUnitIds,
+		dataPlaneRef
 	} from '$lib/stores/vehicleStore.js';
 	import {
 		showH3Grid,
@@ -217,7 +218,7 @@
 				}
 				const extra = extraStreamDeviceIds();
 				const list = get(vehicles);
-				const fromFleet = list.map((v) => v.deviceRef).filter(Boolean);
+				const fromFleet = list.map((v) => dataPlaneRef(v)).filter(Boolean);
 				const ids = [...new Set([...fromFleet.map(String), ...extra])];
 				const key = ids.slice().sort().join('\0');
 				if (key === lastPositionStreamKey) return;

--- a/src/lib/components/MapContainer.svelte
+++ b/src/lib/components/MapContainer.svelte
@@ -217,7 +217,7 @@
 				}
 				const extra = extraStreamDeviceIds();
 				const list = get(vehicles);
-				const fromFleet = list.map((v) => v.deviceId).filter(Boolean);
+				const fromFleet = list.map((v) => v.deviceRef).filter(Boolean);
 				const ids = [...new Set([...fromFleet.map(String), ...extra])];
 				const key = ids.slice().sort().join('\0');
 				if (key === lastPositionStreamKey) return;

--- a/src/lib/services/dataToken.js
+++ b/src/lib/services/dataToken.js
@@ -1,0 +1,206 @@
+/**
+ * Credencial del plano de datos (siscom-api).
+ *
+ * siscom-api no verifica el token de sesión: verifica un PASETO v4.public
+ * emitido por la admin-api cuyo contenido es únicamente `{ jti, scope_ref,
+ * aud, iat, nbf, exp }`. No lleva identidad de usuario ni de organización —
+ * el alcance vive en Valkey y siscom-api lo resuelve sin saber de quién es.
+ *
+ * Este módulo es el único dueño de esa credencial. Los call sites no la
+ * obtienen ni la refrescan: piden `withDataToken(...)` y se olvidan.
+ *
+ * Dos invariantes que no son cosméticas:
+ *
+ * 1. **Una sola emisión en vuelo.** Emitir revoca los tokens anteriores del
+ *    mismo sujeto, así que dos emisiones concurrentes se revocan entre sí y
+ *    dejan al usuario sin credencial válida. Se comparte la promesa.
+ * 2. **Un solo reintento.** Por lo mismo: un bucle de reintentos es un bucle
+ *    de revocaciones. Si el segundo intento falla, el error se propaga.
+ *
+ * Solo en memoria, nunca en `localStorage`: vive minutos, se re-obtiene con la
+ * sesión y así no sobrevive a la pestaña ni se cruza entre marcas.
+ */
+
+import { apiService } from './api.js';
+import { logger } from '$lib/utils/logger.js';
+
+/** Se refresca al consumir esta fracción de la vida útil del token. */
+const REFRESH_AT_FRACTION = 0.8;
+
+/** Margen para no presentar un token que expira en vuelo. */
+const EXPIRY_SKEW_MS = 5_000;
+
+/** Vida asumida si el emisor no la declara. El contrato fija 10 min de techo. */
+const FALLBACK_TTL_MS = 600_000;
+
+/**
+ * Marcador de subprotocolo del WebSocket. El servidor hace eco de ESTE valor,
+ * nunca del token, para que la credencial no acabe en los logs del proxy.
+ */
+export const WS_TOKEN_PROTOCOL = 'nexus.data-token';
+
+/** @typedef {{ token: string, expiresAtMs: number, refreshAtMs: number }} DataTokenEntry */
+
+/** @type {DataTokenEntry | null} */
+let cached = null;
+
+/** @type {Promise<DataTokenEntry> | null} */
+let inFlight = null;
+
+/** Error del plano de datos que el token vigente no puede resolver. */
+export class DataPlaneForbiddenError extends Error {
+	/** @param {string} [message] */
+	constructor(message = 'El plano de datos rechazó el alcance solicitado') {
+		super(message);
+		this.name = 'DataPlaneForbiddenError';
+	}
+}
+
+/**
+ * Vida útil declarada por el emisor. El TTL es adaptativo —la admin-api lo
+ * recorta al siguiente límite de ventana horaria—, así que se lee de la
+ * respuesta y no se asume constante.
+ * @param {any} payload
+ * @returns {number} epoch ms
+ */
+function readExpiry(payload) {
+	const seconds = Number(payload?.expires_in);
+	if (Number.isFinite(seconds) && seconds > 0) return Date.now() + seconds * 1000;
+
+	const absolute = payload?.expires_at ?? payload?.exp;
+	if (typeof absolute === 'number' && Number.isFinite(absolute)) {
+		// Segundos epoch si viene como número.
+		return absolute * 1000;
+	}
+	if (typeof absolute === 'string') {
+		const parsed = Date.parse(absolute);
+		if (!Number.isNaN(parsed)) return parsed;
+	}
+	return Date.now() + FALLBACK_TTL_MS;
+}
+
+/**
+ * @param {DataTokenEntry | null} entry
+ * @returns {boolean}
+ */
+function isFresh(entry) {
+	return (
+		Boolean(entry) &&
+		Date.now() + EXPIRY_SKEW_MS < /** @type {DataTokenEntry} */ (entry).refreshAtMs
+	);
+}
+
+/**
+ * @param {DataTokenEntry | null} entry
+ * @returns {boolean}
+ */
+function isUsable(entry) {
+	return (
+		Boolean(entry) &&
+		Date.now() + EXPIRY_SKEW_MS < /** @type {DataTokenEntry} */ (entry).expiresAtMs
+	);
+}
+
+/**
+ * Pide un token nuevo a la admin-api. No llamar directamente: pasa por
+ * `getDataToken`, que garantiza una sola emisión en vuelo.
+ * @returns {Promise<DataTokenEntry>}
+ */
+async function issue() {
+	const payload = await apiService.request('/auth/data-token', { method: 'POST' });
+	const token = payload?.data_token ?? payload?.token ?? payload?.access_token;
+
+	if (typeof token !== 'string' || !token) {
+		throw new Error('La admin-api no devolvió un token de plano de datos');
+	}
+
+	const expiresAtMs = readExpiry(payload);
+	const lifetime = Math.max(expiresAtMs - Date.now(), 0);
+
+	return {
+		token,
+		expiresAtMs,
+		refreshAtMs: Date.now() + lifetime * REFRESH_AT_FRACTION
+	};
+}
+
+/**
+ * Devuelve un token utilizable, emitiendo o refrescando si hace falta.
+ * @param {{ force?: boolean }} [options]
+ * @returns {Promise<string>}
+ */
+export async function getDataToken({ force = false } = {}) {
+	if (!force && isFresh(cached)) return /** @type {DataTokenEntry} */ (cached).token;
+
+	// Si ya hay una emisión en curso, esperarla en vez de lanzar otra: la
+	// segunda revocaría a la primera.
+	if (inFlight) return (await inFlight).token;
+
+	if (force) cached = null;
+
+	inFlight = issue()
+		.then((entry) => {
+			cached = entry;
+			return entry;
+		})
+		.catch((err) => {
+			// Un token todavía válido es mejor que ninguno si el refresco
+			// preventivo falla por un corte puntual.
+			if (!force && isUsable(cached)) {
+				logger.warn({
+					code: 'DATA_TOKEN_REFRESH_FAILED',
+					message: 'Refresco del token de datos fallido; se conserva el vigente',
+					err
+				});
+				return /** @type {DataTokenEntry} */ (cached);
+			}
+			cached = null;
+			throw err;
+		})
+		.finally(() => {
+			inFlight = null;
+		});
+
+	return (await inFlight).token;
+}
+
+/** Descarta la credencial en memoria. Llamar al cerrar sesión. */
+export function clearDataToken() {
+	cached = null;
+	inFlight = null;
+}
+
+/**
+ * Ejecuta una operación con el token vigente y la reintenta **una sola vez**
+ * con un token recién emitido si el plano de datos la rechaza.
+ *
+ * siscom-api responde 403 a la petición entera cuando alguna referencia no
+ * está en el alcance —devolver el subconjunto permitido convertiría la API en
+ * un oráculo para reconstruir flotas ajenas sondeando—. Como la emisión
+ * recalcula el alcance, una referencia que quedó obsoleta desaparece en el
+ * reintento y el caso se cura solo. Si vuelve a fallar, es un rechazo real:
+ * quien llama debe recargar su lista de unidades.
+ *
+ * @template T
+ * @param {(token: string) => Promise<Response>} run
+ * @param {(response: Response) => Promise<T>} parse
+ * @returns {Promise<T>}
+ */
+export async function withDataToken(run, parse) {
+	let response = await run(await getDataToken());
+
+	if (response.status === 401 || response.status === 403) {
+		logger.warn({
+			code: 'DATA_TOKEN_REJECTED',
+			message: 'Plano de datos rechazó el token; reemitiendo y reintentando una vez',
+			context: { status: response.status }
+		});
+		response = await run(await getDataToken({ force: true }));
+	}
+
+	if (response.status === 401 || response.status === 403) {
+		throw new DataPlaneForbiddenError();
+	}
+
+	return parse(response);
+}

--- a/src/lib/services/dataToken.js
+++ b/src/lib/services/dataToken.js
@@ -36,8 +36,13 @@ const FALLBACK_TTL_MS = 600_000;
 /**
  * Marcador de subprotocolo del WebSocket. El servidor hace eco de ESTE valor,
  * nunca del token, para que la credencial no acabe en los logs del proxy.
+ *
+ * Nombra el protocolo y no a quien lo habla: son tres los frontends que hablan
+ * con siscom-api, así que un marcador llamado «nexus» obligaría a gac-web a
+ * anunciarse con el nombre de otro cliente. Lleva versión para poder negociar
+ * el día que cambie el formato.
  */
-export const WS_TOKEN_PROTOCOL = 'nexus.data-token';
+export const WS_TOKEN_PROTOCOL = 'siscom.data-token.v1';
 
 /** @typedef {{ token: string, expiresAtMs: number, refreshAtMs: number }} DataTokenEntry */
 
@@ -89,7 +94,10 @@ function readExpiry(payload) {
  * @returns {DataTokenEntry | null}
  */
 function parseCredential(payload) {
-	const token = payload?.token ?? payload?.data_token ?? payload?.access_token;
+	// Una sola forma, sin alternativas toleradas: aceptar varios nombres para el
+	// mismo campo esconde un renombrado del emisor hasta que algo falla en
+	// producción por un motivo que parece no tener relación.
+	const token = payload?.token;
 	if (typeof token !== 'string' || !token) return null;
 
 	const expiresAtMs = readExpiry(payload);

--- a/src/lib/services/dataToken.js
+++ b/src/lib/services/dataToken.js
@@ -164,6 +164,41 @@ export async function getDataToken({ force = false } = {}) {
 	return (await inFlight).token;
 }
 
+/**
+ * Siembra la credencial con la que `/auth/login` adjunta como conveniencia, y
+ * ahorra un round trip en el arranque en frío — justo cuando el mapa tiene que
+ * pintar.
+ *
+ * La admin-api la adjunta en *best effort*: si el plano de datos no está
+ * configurado o Valkey no responde, viene a `null` y el login sigue siendo
+ * válido. **Eso es funcionamiento normal, no un error**: sin mapa se entra
+ * igual. En ese caso no se siembra nada y el token se pedirá al endpoint
+ * dedicado, que es la autoridad.
+ *
+ * Ojo con la vida útil: el `expires_in` de `/auth/login` es el de la **sesión**
+ * —una hora—, no el del data token, que vive minutos. Leerlo de ahí daría por
+ * fresca una credencial caducada hace rato y todas las peticiones se irían al
+ * camino de reintento. Se usa el campo dedicado, y si no viene, el techo
+ * conservador del contrato.
+ *
+ * @param {{ data_token?: string | null, data_token_expires_in?: number, data_token_expires_at?: string } | null | undefined} payload
+ */
+export function primeDataToken(payload) {
+	const token = payload?.data_token;
+	if (typeof token !== 'string' || !token) return;
+
+	const expiresAtMs = readExpiry({
+		expires_in: payload?.data_token_expires_in,
+		expires_at: payload?.data_token_expires_at
+	});
+	const lifetime = Math.max(expiresAtMs - Date.now(), 0);
+	cached = {
+		token,
+		expiresAtMs,
+		refreshAtMs: Date.now() + lifetime * REFRESH_AT_FRACTION
+	};
+}
+
 /** Descarta la credencial en memoria. Llamar al cerrar sesión. */
 export function clearDataToken() {
 	cached = null;

--- a/src/lib/services/dataToken.js
+++ b/src/lib/services/dataToken.js
@@ -62,6 +62,24 @@ export class DataPlaneForbiddenError extends Error {
 }
 
 /**
+ * El periodo pedido cae entero fuera de la ventana concedida. **No es un
+ * error de credencial y no se reintenta**: reemitir daría exactamente la misma
+ * respuesta.
+ *
+ * Es distinto de una serie vacía a propósito. Devolver `[]` afirmaría que no
+ * hubo telemetría en ese periodo, cuando la hubo y simplemente no es visible.
+ * Los tres estados quedan separados: 403 alcance rechazado (se reintenta), 404
+ * nada visible en ese rango (no se reintenta), 200 con lista vacía sin datos.
+ */
+export class DataPlaneOutOfWindowError extends Error {
+	/** @param {string} [message] */
+	constructor(message = 'El periodo solicitado queda fuera del acceso concedido') {
+		super(message);
+		this.name = 'DataPlaneOutOfWindowError';
+	}
+}
+
+/**
  * Vida útil declarada por el emisor. El TTL es adaptativo —la admin-api lo
  * recorta al siguiente límite de ventana horaria—, así que se lee de la
  * respuesta y no se asume constante.
@@ -249,6 +267,10 @@ export async function withDataToken(run, parse) {
 
 	if (response.status === 401 || response.status === 403) {
 		throw new DataPlaneForbiddenError();
+	}
+
+	if (response.status === 404) {
+		throw new DataPlaneOutOfWindowError();
 	}
 
 	return parse(response);

--- a/src/lib/services/dataToken.js
+++ b/src/lib/services/dataToken.js
@@ -80,6 +80,31 @@ function readExpiry(payload) {
 }
 
 /**
+ * La credencial tiene la **misma forma** en los dos caminos que la producen:
+ * anidada bajo `data_token` en `/auth/login`, y como cuerpo entero en
+ * `POST /auth/data-token`. Un solo parser para ambos — si se aplanara uno de
+ * los dos, harían falta dos y se desincronizarían.
+ *
+ * @param {any} payload
+ * @returns {DataTokenEntry | null}
+ */
+function parseCredential(payload) {
+	const token = payload?.token ?? payload?.data_token ?? payload?.access_token;
+	if (typeof token !== 'string' || !token) return null;
+
+	const expiresAtMs = readExpiry(payload);
+	const lifetime = Math.max(expiresAtMs - Date.now(), 0);
+
+	return {
+		token,
+		expiresAtMs,
+		// Margen proporcional: con un TTL adaptativo de 45 s un margen fijo se
+		// comería casi toda la vida útil.
+		refreshAtMs: Date.now() + lifetime * REFRESH_AT_FRACTION
+	};
+}
+
+/**
  * @param {DataTokenEntry | null} entry
  * @returns {boolean}
  */
@@ -107,21 +132,13 @@ function isUsable(entry) {
  * @returns {Promise<DataTokenEntry>}
  */
 async function issue() {
-	const payload = await apiService.request('/auth/data-token', { method: 'POST' });
-	const token = payload?.data_token ?? payload?.token ?? payload?.access_token;
+	const entry = parseCredential(await apiService.request('/auth/data-token', { method: 'POST' }));
 
-	if (typeof token !== 'string' || !token) {
+	if (!entry) {
 		throw new Error('La admin-api no devolvió un token de plano de datos');
 	}
 
-	const expiresAtMs = readExpiry(payload);
-	const lifetime = Math.max(expiresAtMs - Date.now(), 0);
-
-	return {
-		token,
-		expiresAtMs,
-		refreshAtMs: Date.now() + lifetime * REFRESH_AT_FRACTION
-	};
+	return entry;
 }
 
 /**
@@ -175,28 +192,17 @@ export async function getDataToken({ force = false } = {}) {
  * igual. En ese caso no se siembra nada y el token se pedirá al endpoint
  * dedicado, que es la autoridad.
  *
- * Ojo con la vida útil: el `expires_in` de `/auth/login` es el de la **sesión**
- * —una hora—, no el del data token, que vive minutos. Leerlo de ahí daría por
- * fresca una credencial caducada hace rato y todas las peticiones se irían al
- * camino de reintento. Se usa el campo dedicado, y si no viene, el techo
- * conservador del contrato.
+ * Ojo con la vida útil, porque hay dos `expires_in` en la misma respuesta: el
+ * de primer nivel es el de la **sesión** —una hora—; el que vale está
+ * **dentro** de `data_token` y son minutos, ya con el TTL adaptativo aplicado.
+ * Tomar el de fuera daría por fresca una credencial caducada hace rato y
+ * mandaría cada petición al camino de reintento.
  *
- * @param {{ data_token?: string | null, data_token_expires_in?: number, data_token_expires_at?: string } | null | undefined} payload
+ * @param {{ data_token?: { token?: string, expires_in?: number, expires_at?: string } | null } | null | undefined} loginResponse
  */
-export function primeDataToken(payload) {
-	const token = payload?.data_token;
-	if (typeof token !== 'string' || !token) return;
-
-	const expiresAtMs = readExpiry({
-		expires_in: payload?.data_token_expires_in,
-		expires_at: payload?.data_token_expires_at
-	});
-	const lifetime = Math.max(expiresAtMs - Date.now(), 0);
-	cached = {
-		token,
-		expiresAtMs,
-		refreshAtMs: Date.now() + lifetime * REFRESH_AT_FRACTION
-	};
+export function primeDataToken(loginResponse) {
+	const entry = parseCredential(loginResponse?.data_token);
+	if (entry) cached = entry;
 }
 
 /** Descarta la credencial en memoria. Llamar al cerrar sesión. */

--- a/src/lib/services/eventService.js
+++ b/src/lib/services/eventService.js
@@ -1,7 +1,10 @@
-import { authToken } from '$lib/stores/auth.js';
 import { normalizeEvent } from '$lib/utils/eventUtils.js';
+import { withDataToken } from './dataToken.js';
 
-const COMM_API_URL = import.meta.env?.VITE_COMM_API_URL || 'http://localhost:8000';
+/** Fail-closed: sin VITE_COMM_API_URL no se llama a un host cableado. */
+const COMM_API_URL = String(import.meta.env?.VITE_COMM_API_URL ?? '')
+	.trim()
+	.replace(/\/$/, '');
 
 class EventService {
 	/**
@@ -22,6 +25,10 @@ class EventService {
 			return { from, to };
 		})();
 
+		if (!COMM_API_URL) {
+			throw new Error('VITE_COMM_API_URL is not configured');
+		}
+
 		const url = new URL('/api/v1/events', COMM_API_URL);
 		url.searchParams.append('unit_id', unitId);
 		url.searchParams.set('from', dayFrom.toISOString());
@@ -29,17 +36,20 @@ class EventService {
 		url.searchParams.set('limit', String(limit));
 		url.searchParams.set('order', 'desc');
 
-		const token = authToken.getToken();
-		const headers = { Accept: 'application/json' };
-		if (token) headers.Authorization = `Bearer ${token}`;
-
-		const res = await fetch(url.toString(), { method: 'GET', headers });
-		if (!res.ok) {
-			const body = await res.text().catch(() => '');
-			throw new Error(body || `Error al cargar eventos (${res.status})`);
-		}
-
-		const json = await res.json();
+		const json = await withDataToken(
+			(dataToken) =>
+				fetch(url.toString(), {
+					method: 'GET',
+					headers: { Accept: 'application/json', Authorization: `Bearer ${dataToken}` }
+				}),
+			async (res) => {
+				if (!res.ok) {
+					const body = await res.text().catch(() => '');
+					throw new Error(body || `Error al cargar eventos (${res.status})`);
+				}
+				return res.json();
+			}
+		);
 		const list = Array.isArray(json?.data) ? json.data : [];
 		return {
 			events: list.map(normalizeEvent),

--- a/src/lib/services/positionService.js
+++ b/src/lib/services/positionService.js
@@ -5,6 +5,7 @@
 import { vehicleActions } from '../stores/vehicleStore.js';
 import { authToken } from '../stores/auth.js';
 import { logger } from '$lib/utils/logger.js';
+import { withDataToken, getDataToken, WS_TOKEN_PROTOCOL } from './dataToken.js';
 
 /** Fail-closed: sin VITE_COMM_API_URL no hay llamadas a hosts hardcodeados. */
 const COMM_API_URL = String(import.meta.env?.VITE_COMM_API_URL ?? '')
@@ -21,15 +22,6 @@ function requireCommApiUrl() {
 		throw err;
 	}
 	return COMM_API_URL;
-}
-
-/** @returns {Record<string, string>} */
-function authHeaders() {
-	/** @type {Record<string, string>} */
-	const headers = { Accept: 'application/json' };
-	const token = authToken.getToken?.();
-	if (token) headers.Authorization = `Bearer ${token}`;
-	return headers;
 }
 
 class PositionService {
@@ -59,9 +51,17 @@ class PositionService {
 		const url = new URL('/api/v1/communications/latest', base);
 		deviceIds.forEach((id) => url.searchParams.append('device_ids', String(id)));
 		try {
-			const res = await fetch(url.toString(), { method: 'GET', headers: authHeaders() });
-			if (!res.ok) throw new Error(`HTTP error ${res.status}`);
-			return await res.json();
+			return await withDataToken(
+				(dataToken) =>
+					fetch(url.toString(), {
+						method: 'GET',
+						headers: { Accept: 'application/json', Authorization: `Bearer ${dataToken}` }
+					}),
+				async (res) => {
+					if (!res.ok) throw new Error(`HTTP error ${res.status}`);
+					return res.json();
+				}
+			);
 		} catch (err) {
 			logger.error({
 				code: 'COMM_LATEST_FAILED',
@@ -430,23 +430,37 @@ class PositionService {
 		const deviceIdsParam = deviceIds.map((id) => encodeURIComponent(String(id))).join(',');
 		const baseUrl = this._getWebSocketUrl(base);
 		const sanitizedBaseUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
-		// No poner access_token en query (aparecería en logs/Referer). El backend debe
-		// exigir auth en /stream; el cliente solo abre stream con sesión local válida.
+		// La credencial nunca va en la query: acabaría en los logs de acceso del
+		// ALB y en la cabecera Referer. Viaja como subprotocolo del handshake.
 		const streamUrl = `${sanitizedBaseUrl}/api/v1/stream?device_ids=${deviceIdsParam}`;
 
 		let websocket = null;
 		let reconnectTimer = null;
 		let isClosed = false;
 
-		const connect = () => {
+		const connect = async () => {
 			if (isClosed) return;
 			if (!authToken.getToken?.()) {
 				isClosed = true;
 				return;
 			}
 
+			let dataToken;
 			try {
-				websocket = new WebSocket(streamUrl);
+				dataToken = await getDataToken();
+			} catch (err) {
+				logger.error({
+					code: 'WS_STREAM_TOKEN_FAILED',
+					message: 'Sin token de plano de datos para abrir el stream',
+					err
+				});
+				isClosed = true;
+				return;
+			}
+			if (isClosed) return;
+
+			try {
+				websocket = new WebSocket(streamUrl, [WS_TOKEN_PROTOCOL, dataToken]);
 
 				websocket.onopen = () => {};
 

--- a/src/lib/services/sessionService.js
+++ b/src/lib/services/sessionService.js
@@ -1,5 +1,6 @@
 import { user, authToken } from '$lib/stores/auth.js';
 import { apiService } from '$lib/services/api.js';
+import { clearDataToken } from '$lib/services/dataToken.js';
 import { logger } from '$lib/utils/logger.js';
 
 /** @param {Record<string, unknown> | null | undefined} apiUser */
@@ -30,6 +31,9 @@ export function persistLoginResponse(response) {
 export function clearLocalSession() {
 	user.logout();
 	authToken.clearToken();
+	// La credencial del plano de datos deriva de la sesión: si la sesión muere,
+	// muere con ella. Vive solo en memoria, así que basta con soltarla.
+	clearDataToken();
 }
 
 export async function logoutSession() {

--- a/src/lib/services/sessionService.js
+++ b/src/lib/services/sessionService.js
@@ -1,6 +1,6 @@
 import { user, authToken } from '$lib/stores/auth.js';
 import { apiService } from '$lib/services/api.js';
-import { clearDataToken } from '$lib/services/dataToken.js';
+import { clearDataToken, primeDataToken } from '$lib/services/dataToken.js';
 import { logger } from '$lib/utils/logger.js';
 
 /** @param {Record<string, unknown> | null | undefined} apiUser */
@@ -17,7 +17,7 @@ export function normalizeUser(apiUser) {
 	};
 }
 
-/** @param {{ access_token?: string, refresh_token?: string, id_token?: string, expires_in?: number, user?: Record<string, unknown> }} response */
+/** @param {{ access_token?: string, refresh_token?: string, id_token?: string, expires_in?: number, data_token?: string | null, user?: Record<string, unknown> }} response */
 export function persistLoginResponse(response) {
 	authToken.setSession({
 		access_token: response.access_token,
@@ -25,6 +25,9 @@ export function persistLoginResponse(response) {
 		id_token: response.id_token,
 		expires_in: response.expires_in
 	});
+	// Conveniencia: si el login trae la credencial del plano de datos, el mapa
+	// pinta sin un round trip extra. Si no la trae, se pide al endpoint dedicado.
+	primeDataToken(response);
 	user.login(normalizeUser(response.user));
 }
 

--- a/src/lib/services/vehiclePositionStream.js
+++ b/src/lib/services/vehiclePositionStream.js
@@ -1,9 +1,11 @@
 import { logger } from '$lib/utils/logger.js';
 import { authToken } from '$lib/stores/auth.js';
+import { getDataToken, WS_TOKEN_PROTOCOL } from './dataToken.js';
 /**
  * Cliente WebSocket para posiciones en vivo (siscom-api /api/v1/stream).
  * La base WS se deriva de VITE_COMM_API_URL (http→ws, https→wss), igual que positionService.
- * Requiere sesión local; el backend debe exigir auth en /stream (pendiente en API).
+ * La credencial del plano de datos viaja como subprotocolo del handshake, nunca
+ * en la query: siscom-api valida ANTES de aceptar la conexión.
  */
 
 const STREAM_PATH = '/api/v1/stream';
@@ -154,14 +156,29 @@ export function startVehiclePositionStream(deviceIds, onPosition) {
 
 	const url = `${base}${STREAM_PATH}?device_ids=${encodeURIComponent(unique.join(','))}`;
 
-	const connect = () => {
+	const connect = async () => {
 		if (stopped) return;
 		if (!authToken.getToken?.()) {
 			stopped = true;
 			return;
 		}
+
+		let dataToken;
 		try {
-			ws = new WebSocket(url);
+			dataToken = await getDataToken();
+		} catch (err) {
+			logger.error({
+				code: 'WS_STREAM_TOKEN_FAILED',
+				message: 'Sin token de plano de datos para abrir el stream',
+				err
+			});
+			stopped = true;
+			return;
+		}
+		if (stopped) return;
+
+		try {
+			ws = new WebSocket(url, [WS_TOKEN_PROTOCOL, dataToken]);
 		} catch (e) {
 			logger.warn({
 				code: 'WS_STREAM_CONNECT_FAILED',

--- a/src/lib/stores/telemetryStore.js
+++ b/src/lib/stores/telemetryStore.js
@@ -1,6 +1,6 @@
 import { writable, derived, get } from 'svelte/store';
 import { apiService } from '$lib/services/api.js';
-import { vehicles } from '$lib/stores/vehicleStore.js';
+import { vehicles, dataPlaneRef } from '$lib/stores/vehicleStore.js';
 import {
 	TELEMETRY_METRICS,
 	processTelemetryResults,
@@ -98,7 +98,8 @@ export const telemetryActions = {
 				.map((unitId) => {
 					const unit = allVehicles.find((v) => v.id === unitId);
 					// La telemetría de la admin-api acepta la referencia opaca en el path.
-					return unit?.deviceRef ? { id: unitId, name: unit.name, deviceId: unit.deviceRef } : null;
+					const ref = dataPlaneRef(unit);
+					return ref ? { id: unitId, name: unit.name, deviceId: ref } : null;
 				})
 				.filter(Boolean);
 

--- a/src/lib/stores/telemetryStore.js
+++ b/src/lib/stores/telemetryStore.js
@@ -97,7 +97,8 @@ export const telemetryActions = {
 			const unitsMeta = unitIds
 				.map((unitId) => {
 					const unit = allVehicles.find((v) => v.id === unitId);
-					return unit?.deviceId ? { id: unitId, name: unit.name, deviceId: unit.deviceId } : null;
+					// La telemetría de la admin-api acepta la referencia opaca en el path.
+					return unit?.deviceRef ? { id: unitId, name: unit.name, deviceId: unit.deviceRef } : null;
 				})
 				.filter(Boolean);
 

--- a/src/lib/stores/vehicleStore.js
+++ b/src/lib/stores/vehicleStore.js
@@ -6,6 +6,26 @@ import { colorSlugToHex, formatLastUpdate } from '$lib/utils/vehicleUtils.js';
 import { logger } from '$lib/utils/logger.js';
 
 // Estado principal de vehículos
+/**
+ * Identificador con el que se habla con el plano de datos.
+ *
+ * `deviceRef` es la referencia opaca y es lo correcto. El respaldo al IMEI
+ * existe solo para que este cliente pueda desplegarse **antes** que la
+ * admin-api que expone `device_ref`: sin él, los vehículos se filtrarían por
+ * falta de referencia y el mapa quedaría vacío en silencio, sin error.
+ *
+ * siscom-api acepta ambos espacios y responde en el que se le pregunta, así
+ * que la transición es transparente. **Retirar este respaldo** cuando las tres
+ * APIs expongan `device_ref` en producción — mientras exista, el IMEI puede
+ * seguir viajando en la query string.
+ *
+ * @param {{ deviceRef?: string | null, deviceId?: string | null }} vehicle
+ * @returns {string | null}
+ */
+export function dataPlaneRef(vehicle) {
+	return vehicle?.deviceRef || vehicle?.deviceId || null;
+}
+
 export const vehicles = writable([]);
 export const selectedVehicles = writable([]);
 /** IDs de unidades visibles en el mapa (marcadores). */
@@ -203,8 +223,8 @@ export const vehicleActions = {
 		try {
 			const currentVehicles = get(vehicles);
 
-			const vehiclesWithDeviceId = currentVehicles.filter((v) => v.deviceRef);
-			const deviceIds = vehiclesWithDeviceId.map((v) => v.deviceRef);
+			const vehiclesWithDeviceId = currentVehicles.filter((v) => dataPlaneRef(v));
+			const deviceIds = vehiclesWithDeviceId.map((v) => dataPlaneRef(v));
 
 			if (deviceIds.length > 0) {
 				const positions = await positionService.getMultiplePositions(deviceIds);
@@ -220,8 +240,9 @@ export const vehicleActions = {
 
 				// Actualizar vehículos con datos de posición
 				const updatedVehicles = currentVehicles.map((vehicle) => {
-					if (vehicle.deviceRef) {
-						const position = positionMap.get(vehicle.deviceRef);
+					const ref = dataPlaneRef(vehicle);
+					if (ref) {
+						const position = positionMap.get(ref);
 						if (position) {
 							return {
 								...vehicle,
@@ -272,7 +293,7 @@ export const vehicleActions = {
 		let updatedVehicle = null;
 		vehicles.update((vehicleList) =>
 			vehicleList.map((vehicle) => {
-				if (String(vehicle.deviceRef ?? '') !== did) return vehicle;
+				if (String(dataPlaneRef(vehicle) ?? '') !== did) return vehicle;
 				const now = new Date().toISOString();
 				updatedVehicle = {
 					...vehicle,
@@ -312,7 +333,7 @@ export const vehicleActions = {
 			// Actualizar el vehículo en la lista
 			vehicles.update((vehicleList) => {
 				return vehicleList.map((vehicle) => {
-					if (vehicle.deviceRef === deviceId) {
+					if (dataPlaneRef(vehicle) === deviceId) {
 						return {
 							...vehicle,
 							latitude: position.latitude,

--- a/src/lib/stores/vehicleStore.js
+++ b/src/lib/stores/vehicleStore.js
@@ -72,7 +72,12 @@ function mapUnitToVehicle(unit) {
 		name: unit?.name || 'Unidad',
 		description: unit?.description || '',
 		driver: '',
+		// deviceId es el IMEI y solo se muestra. deviceRef es la referencia opaca
+		// y es la ÚNICA que viaja por el cable: el IMEI no debe salir del cliente
+		// ni aparecer en query strings, que acaban en los logs del ALB.
 		deviceId: unit?.device_id || unit?.deviceId || null,
+		deviceRef: unit?.device_ref || unit?.deviceRef || null,
+		unitRef: unit?.unit_ref || unit?.unitRef || null,
 		status: unit?.deleted_at ? 'inactive' : 'active',
 		location: unit?.description || '',
 		lastUpdate: createdAt,
@@ -96,6 +101,8 @@ function mergeVehicleDetail(existing, mapped) {
 		...existing,
 		...mapped,
 		deviceId: mapped.deviceId || existing.deviceId || null,
+		deviceRef: mapped.deviceRef || existing.deviceRef || null,
+		unitRef: mapped.unitRef || existing.unitRef || null,
 		latitude: mapped.latitude ?? existing.latitude,
 		longitude: mapped.longitude ?? existing.longitude,
 		speed: mapped.speed ?? existing.speed,
@@ -196,8 +203,8 @@ export const vehicleActions = {
 		try {
 			const currentVehicles = get(vehicles);
 
-			const vehiclesWithDeviceId = currentVehicles.filter((v) => v.deviceId);
-			const deviceIds = vehiclesWithDeviceId.map((v) => v.deviceId);
+			const vehiclesWithDeviceId = currentVehicles.filter((v) => v.deviceRef);
+			const deviceIds = vehiclesWithDeviceId.map((v) => v.deviceRef);
 
 			if (deviceIds.length > 0) {
 				const positions = await positionService.getMultiplePositions(deviceIds);
@@ -213,8 +220,8 @@ export const vehicleActions = {
 
 				// Actualizar vehículos con datos de posición
 				const updatedVehicles = currentVehicles.map((vehicle) => {
-					if (vehicle.deviceId) {
-						const position = positionMap.get(vehicle.deviceId);
+					if (vehicle.deviceRef) {
+						const position = positionMap.get(vehicle.deviceRef);
 						if (position) {
 							return {
 								...vehicle,
@@ -265,7 +272,7 @@ export const vehicleActions = {
 		let updatedVehicle = null;
 		vehicles.update((vehicleList) =>
 			vehicleList.map((vehicle) => {
-				if (String(vehicle.deviceId ?? '') !== did) return vehicle;
+				if (String(vehicle.deviceRef ?? '') !== did) return vehicle;
 				const now = new Date().toISOString();
 				updatedVehicle = {
 					...vehicle,
@@ -305,7 +312,7 @@ export const vehicleActions = {
 			// Actualizar el vehículo en la lista
 			vehicles.update((vehicleList) => {
 				return vehicleList.map((vehicle) => {
-					if (vehicle.deviceId === deviceId) {
+					if (vehicle.deviceRef === deviceId) {
 						return {
 							...vehicle,
 							latitude: position.latitude,

--- a/tests/dataToken.test.js
+++ b/tests/dataToken.test.js
@@ -10,7 +10,8 @@ vi.mock('../src/lib/services/api.js', () => ({
 /** @param {number} [expiresIn] */
 function issued(expiresIn = 600) {
 	let n = 0;
-	return () => Promise.resolve({ data_token: `token-${++n}`, expires_in: expiresIn });
+	return () =>
+		Promise.resolve({ token: `token-${++n}`, expires_in: expiresIn, token_type: 'Bearer' });
 }
 
 async function load() {
@@ -48,7 +49,7 @@ describe('dataToken', () => {
 		const { getDataToken } = await load();
 
 		const all = Promise.all([getDataToken(), getDataToken(), getDataToken()]);
-		release({ data_token: 'token-1', expires_in: 600 });
+		release({ token: 'token-1', expires_in: 600 });
 
 		expect(await all).toEqual(['token-1', 'token-1', 'token-1']);
 		expect(requestMock).toHaveBeenCalledTimes(1);
@@ -101,7 +102,10 @@ describe('dataToken', () => {
 		requestMock.mockImplementation(issued());
 		const { primeDataToken, getDataToken } = await load();
 
-		primeDataToken({ data_token: 'del-login', data_token_expires_in: 600 });
+		primeDataToken({
+			expires_in: 3600,
+			data_token: { token: 'del-login', expires_in: 600, token_type: 'Bearer' }
+		});
 
 		expect(await getDataToken()).toBe('del-login');
 		expect(requestMock).not.toHaveBeenCalled();
@@ -119,15 +123,19 @@ describe('dataToken', () => {
 		expect(requestMock).toHaveBeenCalledTimes(1);
 	});
 
-	// El expires_in del login es el de la sesión (una hora), no el del data
-	// token. Tomarlo daría por fresca una credencial caducada.
-	it('no toma la vida de la sesión como vida del data token', async () => {
+	// Hay dos expires_in en la respuesta de login: el de fuera es el de la
+	// sesión (una hora) y el de dentro el del data token (minutos). Tomar el de
+	// fuera daría por fresca una credencial caducada hace rato.
+	it('usa la vida del data token, no la de la sesión que lo envuelve', async () => {
 		requestMock.mockImplementation(issued());
 		const { primeDataToken, getDataToken } = await load();
 
-		primeDataToken({ data_token: 'del-login', expires_in: 3600 });
+		primeDataToken({
+			expires_in: 3600,
+			data_token: { token: 'del-login', expires_in: 600 }
+		});
 
-		// Pasados 9 minutos, el techo de 10 del contrato ya obliga a refrescar.
+		// A los 9 minutos, la credencial sembrada ya entró en su último 20%.
 		vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 9 * 60_000);
 		expect(await getDataToken()).toBe('token-1');
 	});

--- a/tests/dataToken.test.js
+++ b/tests/dataToken.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$app/environment', () => ({ browser: true }));
+
+const requestMock = vi.fn();
+vi.mock('../src/lib/services/api.js', () => ({
+	apiService: { request: (/** @type {any} */ ...args) => requestMock(...args) }
+}));
+
+/** @param {number} [expiresIn] */
+function issued(expiresIn = 600) {
+	let n = 0;
+	return () => Promise.resolve({ data_token: `token-${++n}`, expires_in: expiresIn });
+}
+
+async function load() {
+	vi.resetModules();
+	return import('../src/lib/services/dataToken.js');
+}
+
+describe('dataToken', () => {
+	beforeEach(() => {
+		requestMock.mockReset();
+		vi.useRealTimers();
+	});
+
+	it('pide el token al emisor y lo reutiliza mientras esté fresco', async () => {
+		requestMock.mockImplementation(issued());
+		const { getDataToken } = await load();
+
+		expect(await getDataToken()).toBe('token-1');
+		expect(await getDataToken()).toBe('token-1');
+		expect(requestMock).toHaveBeenCalledTimes(1);
+		expect(requestMock).toHaveBeenCalledWith('/auth/data-token', { method: 'POST' });
+	});
+
+	// Emitir revoca los tokens anteriores del mismo sujeto: dos emisiones
+	// concurrentes se revocarían entre sí y dejarían al usuario sin credencial.
+	it('comparte una sola emisión entre llamadas concurrentes', async () => {
+		/** @type {(value: any) => void} */
+		let release = () => {};
+		requestMock.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					release = resolve;
+				})
+		);
+		const { getDataToken } = await load();
+
+		const all = Promise.all([getDataToken(), getDataToken(), getDataToken()]);
+		release({ data_token: 'token-1', expires_in: 600 });
+
+		expect(await all).toEqual(['token-1', 'token-1', 'token-1']);
+		expect(requestMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('reemite cuando el token entra en su último 20% de vida', async () => {
+		requestMock.mockImplementation(issued(100));
+		const { getDataToken } = await load();
+
+		expect(await getDataToken()).toBe('token-1');
+
+		// 85 s de una vida de 100 s: pasado el umbral de refresco (80%).
+		vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 85_000);
+		expect(await getDataToken()).toBe('token-2');
+		expect(requestMock).toHaveBeenCalledTimes(2);
+	});
+
+	it('reintenta UNA sola vez ante un 403 y propaga si vuelve a fallar', async () => {
+		requestMock.mockImplementation(issued());
+		const { withDataToken, DataPlaneForbiddenError } = await load();
+
+		const run = vi.fn(async () => new Response('nope', { status: 403 }));
+
+		await expect(withDataToken(run, async (r) => r.text())).rejects.toBeInstanceOf(
+			DataPlaneForbiddenError
+		);
+
+		// Un bucle de reintentos sería un bucle de revocaciones.
+		expect(run).toHaveBeenCalledTimes(2);
+		expect(run.mock.calls[0][0]).toBe('token-1');
+		expect(run.mock.calls[1][0]).toBe('token-2');
+	});
+
+	it('el reintento con token fresco resuelve el caso de alcance obsoleto', async () => {
+		requestMock.mockImplementation(issued());
+		const { withDataToken } = await load();
+
+		const run = vi
+			.fn()
+			.mockResolvedValueOnce(new Response('nope', { status: 403 }))
+			.mockResolvedValueOnce(new Response('{"ok":true}', { status: 200 }));
+
+		const parsed = await withDataToken(run, async (r) => r.json());
+
+		expect(parsed).toEqual({ ok: true });
+		expect(run).toHaveBeenCalledTimes(2);
+	});
+
+	it('clearDataToken obliga a volver a emitir', async () => {
+		requestMock.mockImplementation(issued());
+		const { getDataToken, clearDataToken } = await load();
+
+		expect(await getDataToken()).toBe('token-1');
+		clearDataToken();
+		expect(await getDataToken()).toBe('token-2');
+	});
+
+	it('conserva el token vigente si falla un refresco preventivo', async () => {
+		requestMock.mockImplementationOnce(issued(100)).mockRejectedValue(new Error('sin red'));
+		const { getDataToken } = await load();
+
+		expect(await getDataToken()).toBe('token-1');
+
+		vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 85_000);
+		expect(await getDataToken()).toBe('token-1');
+	});
+});

--- a/tests/dataToken.test.js
+++ b/tests/dataToken.test.js
@@ -140,6 +140,20 @@ describe('dataToken', () => {
 		expect(await getDataToken()).toBe('token-1');
 	});
 
+	// 404 no se reintenta: reemitir daría la misma respuesta. Y no puede
+	// colapsarse con la serie vacía, que afirmaría que no hubo telemetría.
+	it('no reintenta ante un 404 y lo distingue del rechazo de alcance', async () => {
+		requestMock.mockImplementation(issued());
+		const { withDataToken, DataPlaneOutOfWindowError } = await load();
+
+		const run = vi.fn(async () => new Response('', { status: 404 }));
+
+		await expect(withDataToken(run, async (r) => r.text())).rejects.toBeInstanceOf(
+			DataPlaneOutOfWindowError
+		);
+		expect(run).toHaveBeenCalledTimes(1);
+	});
+
 	it('clearDataToken obliga a volver a emitir', async () => {
 		requestMock.mockImplementation(issued());
 		const { getDataToken, clearDataToken } = await load();

--- a/tests/dataToken.test.js
+++ b/tests/dataToken.test.js
@@ -173,3 +173,24 @@ describe('dataToken', () => {
 		expect(await getDataToken()).toBe('token-1');
 	});
 });
+
+describe('dataPlaneRef', () => {
+	// El respaldo existe para que este cliente pueda desplegarse antes que la
+	// admin-api que expone device_ref: sin él, los vehículos se filtrarían por
+	// falta de referencia y el mapa quedaría vacío en silencio.
+	it('prefiere la referencia opaca cuando existe', async () => {
+		const { dataPlaneRef } = await import('../src/lib/stores/vehicleStore.js');
+		expect(dataPlaneRef({ deviceRef: 'ref-1', deviceId: '864537040123456' })).toBe('ref-1');
+	});
+
+	it('cae al IMEI mientras la admin-api no exponga device_ref', async () => {
+		const { dataPlaneRef } = await import('../src/lib/stores/vehicleStore.js');
+		expect(dataPlaneRef({ deviceRef: null, deviceId: '864537040123456' })).toBe('864537040123456');
+	});
+
+	it('devuelve null si no hay ninguno', async () => {
+		const { dataPlaneRef } = await import('../src/lib/stores/vehicleStore.js');
+		expect(dataPlaneRef({})).toBeNull();
+		expect(dataPlaneRef(null)).toBeNull();
+	});
+});

--- a/tests/dataToken.test.js
+++ b/tests/dataToken.test.js
@@ -97,6 +97,41 @@ describe('dataToken', () => {
 		expect(run).toHaveBeenCalledTimes(2);
 	});
 
+	it('siembra la credencial que adjunta el login y evita el round trip', async () => {
+		requestMock.mockImplementation(issued());
+		const { primeDataToken, getDataToken } = await load();
+
+		primeDataToken({ data_token: 'del-login', data_token_expires_in: 600 });
+
+		expect(await getDataToken()).toBe('del-login');
+		expect(requestMock).not.toHaveBeenCalled();
+	});
+
+	// El plano de datos no puede impedir iniciar sesión: sin Valkey se entra y se
+	// ve la aplicación sin mapa. `data_token: null` es normal, no un error.
+	it('ignora un login sin data_token y pide el token al endpoint dedicado', async () => {
+		requestMock.mockImplementation(issued());
+		const { primeDataToken, getDataToken } = await load();
+
+		primeDataToken({ data_token: null });
+
+		expect(await getDataToken()).toBe('token-1');
+		expect(requestMock).toHaveBeenCalledTimes(1);
+	});
+
+	// El expires_in del login es el de la sesión (una hora), no el del data
+	// token. Tomarlo daría por fresca una credencial caducada.
+	it('no toma la vida de la sesión como vida del data token', async () => {
+		requestMock.mockImplementation(issued());
+		const { primeDataToken, getDataToken } = await load();
+
+		primeDataToken({ data_token: 'del-login', expires_in: 3600 });
+
+		// Pasados 9 minutos, el techo de 10 del contrato ya obliga a refrescar.
+		vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 9 * 60_000);
+		expect(await getDataToken()).toBe('token-1');
+	});
+
 	it('clearDataToken obliga a volver a emitir', async () => {
 		requestMock.mockImplementation(issued());
 		const { getDataToken, clearDataToken } = await load();

--- a/tests/eventService.test.js
+++ b/tests/eventService.test.js
@@ -2,6 +2,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('$app/environment', () => ({ browser: true }));
 
+// eventService ya no manda el token de sesión: siscom-api verifica una
+// credencial de plano de datos. El ciclo de vida de esa credencial se prueba
+// aparte, en dataToken.test.js; aquí solo interesa que llegue a la cabecera.
+vi.mock('../src/lib/services/dataToken.js', () => ({
+	withDataToken: (/** @type {any} */ run, /** @type {any} */ parse) => run('data-token').then(parse)
+}));
+
 describe('eventService', () => {
 	beforeEach(() => {
 		vi.resetModules();
@@ -37,7 +44,7 @@ describe('eventService', () => {
 			eventType: 'ignition_on',
 			id: 's1_1_ignition_on'
 		});
-		expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe('Bearer access-token');
+		expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe('Bearer data-token');
 	});
 
 	it('getEventsForUnit throws on HTTP error', async () => {


### PR DESCRIPTION
## Contexto

Parte de la **Fase 1 (aislamiento del plano de datos)** del proyecto white-label multi-tenant. Este es el lado cliente; hay cuatro PRs más en `siscom-api` y `siscom-admin-api`.

📄 **Documento de arquitectura:** https://claude.ai/code/artifact/ac524e0d-ed0c-4361-b712-2ee9161c9bbd
- **§6** — el contrato del data token y los hallazgos de la auditoría
- **§14** — la configuración que hay que crear en GitHub/AWS antes de desplegar
- **§11** — el roadmap y qué depende de qué

**El problema que resuelve:** hoy el navegador manda a siscom-api el token de sesión de Cognito, que lleva `sub` —identificador estable y global del usuario— y sirve para hablar con toda la admin-api. Dárselo a un servicio del plano de datos significa que ese servicio puede correlacionar sesiones y construir un perfil de usuario, y que comprometerlo abre el plano de control.

## Qué hace

- **`src/lib/services/dataToken.js`** — dueño único de la credencial del plano de datos. Un PASETO v4.public cuyo contenido es solo `{ jti, scope_ref, aud, iat, nbf, exp }`: sin usuario, sin organización, sin lista de dispositivos. El alcance vive en Valkey, así que siscom-api autoriza sin poder saber de quién es la flota.
- **Los WebSockets pasan la credencial por subprotocolo** (`siscom.data-token.v1`) en vez de la query string. En v4.public el payload va en claro y una query acaba en los logs del ALB y en la cabecera `Referer`.
- **El IMEI deja de viajar por el cable.** `deviceRef` opaco sustituye a `device_id` en query strings y paths; `deviceId` se conserva solo para mostrar en pantalla. Sacarlo del token y dejarlo en la URL habría sido moverlo del sitio cifrado a los logs.
- **Tres estados diferenciados** del plano de datos, que antes se confundían: `403` alcance rechazado (se reemite y reintenta una vez), `404` nada visible en el rango pedido (no se reintenta), `200` con lista vacía sin datos.
- De paso, `eventService` deja de caer a un `http://localhost:8000` cableado si falta la configuración, igual que ya hacía `positionService`.

## Qué NO hace

- **No exige nada todavía.** siscom-api verifica en modo observación (`DATA_TOKEN_ENFORCED=false`) y acepta ambos espacios de identificador. Este PR se puede desplegar en cualquier orden respecto a los otros cuatro.
- No toca `gac-web` ni las apps móviles, que consumen siscom-api directo y necesitarán el mismo trabajo (§13 para el registro de iOS).
- No retira el respaldo al IMEI — ver abajo.

## Riesgo al desplegar

🟢 **Ninguno.** El cliente pide la credencial y la usa; si la admin-api todavía no expone `device_ref`, `dataPlaneRef()` cae al IMEI y todo sigue funcionando como hoy.

> ⚠️ **Mergear no despliega.** Este repo despliega por etiqueta `v*.*.*`.

**Un aviso sobre el respaldo temporal:** `dataPlaneRef()` (`src/lib/stores/vehicleStore.js`) prefiere la referencia opaca y cae al IMEI cuando falta. Existe **solo** para que este PR sea independiente del orden de despliegue: sin él, desplegar antes que la admin-api dejaba el mapa vacío en silencio —los vehículos venían sin referencia, el filtro los descartaba todos, sin error ni log—. **Mientras el respaldo exista, el IMEI puede seguir viajando en la query string.** Se retira cuando las tres APIs expongan `device_ref` en producción.

## Cómo probar la rama en local

```bash
git fetch origin
git checkout feature/fase-1-aislamiento
npm ci
npm run validate     # lint + check + tests con cobertura + build
npm run dev
```

### Comprobaciones en local

- [ ] `npm run test:coverage` — 108 tests en verde
- [ ] `npm run lint` y `npm run check` limpios (0 errores, 0 avisos)
- [ ] **La aplicación arranca y el mapa carga posiciones.** Los tests no lo cubren, y en este proyecto ya se nos escapó un fallo que solo aparecía al levantar el servicio
- [ ] **El camino viejo sigue funcionando**: con una admin-api que *no* devuelva `device_ref`, el mapa debe seguir cargando posiciones vía el respaldo al IMEI. Es la garantía de que desplegar esto solo no rompe nada
- [ ] Cerrar sesión y volver a entrar: la credencial se descarta y se vuelve a pedir

### Qué mirar con especial atención

**`dataToken.js` tiene dos invariantes que no son cosméticas**, porque emitir revoca los tokens anteriores del mismo sujeto:

1. **Una sola emisión en vuelo.** Dos emisiones concurrentes se revocarían entre sí y dejarían al usuario sin credencial válida. Por eso se comparte la promesa en vez de lanzar dos peticiones.
2. **Un solo reintento.** Por lo mismo: un bucle de reintentos sería un bucle de revocaciones.

**Tests que fijan propiedades, no comportamiento.** Si alguno se rompe en el futuro no es un test frágil: es la propiedad que se cayó.

- `comparte una sola emisión entre llamadas concurrentes` — la invariante 1
- `reintenta UNA sola vez ante un 403 y propaga si vuelve a fallar` — la invariante 2
- `no toma la vida de la sesión como vida del data token` — hay dos `expires_in` en la respuesta de login, en niveles distintos; tomar el de fuera daría por fresca una credencial caducada hace cincuenta minutos y mandaría cada petición al camino de reintento
- `no reintenta ante un 404 y lo distingue del rechazo de alcance` — que nadie unifique los dos códigos «por consistencia»
- `cae al IMEI mientras la admin-api no exponga device_ref` — el respaldo temporal

## Comprobaciones en producción (después de desplegar)

**Antes de etiquetar:** nada específico de este PR. La variable `ALLOWED_ORIGINS` de siscom-api (§14) es prerrequisito del PR de *aquel* repo, no de éste.

**Después de etiquetar:**

- [ ] Iniciar sesión y confirmar que el mapa carga posiciones
- [ ] En la pestaña de red del navegador: las llamadas a `/api/v1/communications/latest` llevan `Authorization: Bearer v4.public.…` — **no** el token de Cognito
- [ ] El WebSocket de posiciones conecta y el subprotocolo negociado es `siscom.data-token.v1`
- [ ] Las posiciones en vivo se mueven en el mapa
- [ ] Compartir ubicación de una unidad sigue generando un enlace que abre correctamente
- [ ] La consola del navegador no trae `DATA_TOKEN_REJECTED` repetido (uno aislado tras un cambio de permisos es normal; en bucle no)

**Cómo revertir:** etiqueta anterior. Este PR no cambia estado en el servidor ni migra datos.

## Orden de merge y despliegue

Este PR es el **5.º de 5**, y es el único sin dependencias de orden gracias al respaldo al IMEI.

| # | Repo | Contenido | Riesgo |
|---|---|---|---|
| 1 | siscom-api | Seguridad: CORS, `accept()`, endpoints muertos, doble clave | 🔴 |
| 2 | siscom-admin-api | Seguridad: separación de claves, `decode_any_token` | 🔴 |
| 3 | siscom-admin-api | Data token, refs, ventanas temporales | 🟢 |
| 4 | siscom-api | Verificación, traducción, recorte | 🟢 |
| **5** | **nexus-web-page** | **Este PR** | 🟢 |

Los dos primeros cierran una escalada de privilegios abierta hoy y siguen una secuencia de despliegue estricta entre repos (§14). Éste puede mergearse y desplegarse cuando convenga.

**Lo que enciende todo** es `DATA_TOKEN_ENFORCED=true` en siscom-api, que es una decisión aparte y posterior. Ese interruptor rompe `gac-web`, que consume siscom-api directo y queda fuera del alcance de esta fase (§6).
